### PR TITLE
Feat/#13 ChannelCircle 컴포넌트 구현

### DIFF
--- a/__test__/components/Sidebar/ChannelCircle/ChannelCircle.test.tsx
+++ b/__test__/components/Sidebar/ChannelCircle/ChannelCircle.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import ChannelCircle from '@components/Sidebar/ChannelCircle/ChannelCircle';
+
+describe('채널 테스트', () => {
+  const initalState = {
+    channelId: 'ab5gx',
+    channelName: '부경대 총장기',
+    channelGame: 'TFT',
+  };
+
+  it('채널 이름을 가진 컴포넌트가 있다.', () => {
+    render(<ChannelCircle {...initalState} />);
+    const nameEl = screen.getByText('부경대 총장기');
+    expect(nameEl).toBeInTheDocument();
+  });
+
+  const initalState2 = {
+    channelId: 'ab5gx',
+    channelName: '부경대 총장기',
+    channelGame: 'TFT',
+    imgSrc: '1.jpeg',
+  };
+
+  it('백그라운드 사진이 있다.', () => {
+    render(<ChannelCircle {...initalState2} />);
+    const backgroundBtnEl = screen.getByRole('button');
+    expect(backgroundBtnEl).toHaveStyle(`background-image: url(${initalState2.imgSrc})`);
+  });
+});

--- a/src/@types/channelCircle.ts
+++ b/src/@types/channelCircle.ts
@@ -1,0 +1,6 @@
+export interface ChannelCircleProps {
+  channelId: string;
+  channelName: string;
+  channelGame: string;
+  imgSrc?: string;
+}

--- a/src/components/Sidebar/ChannelCircle/ChannelCircle.tsx
+++ b/src/components/Sidebar/ChannelCircle/ChannelCircle.tsx
@@ -1,14 +1,9 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
-interface Props {
-  channelId: string;
-  channelName: string;
-  channelGame: string;
-  imgSrc?: string;
-}
+import { ChannelCircleProps } from 'src/@types/channelCircle';
 
-const ChannelCircle = ({ channelId, channelName, channelGame, imgSrc }: Props) => {
+const ChannelCircle = ({ channelId, channelName, channelGame, imgSrc }: ChannelCircleProps) => {
   return (
     <ChannelBtn key={channelId} url={imgSrc}>
       <ChannelName>{channelName}</ChannelName>

--- a/src/components/Sidebar/ChannelCircle/ChannelCircle.tsx
+++ b/src/components/Sidebar/ChannelCircle/ChannelCircle.tsx
@@ -1,0 +1,69 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+interface Props {
+  channelId: string;
+  channelName: string;
+  channelGame: string;
+  imgSrc?: string;
+}
+
+const ChannelCircle = ({ channelId, channelName, channelGame, imgSrc }: Props) => {
+  return (
+    <ChannelBtn key={channelId} url={imgSrc}>
+      <ChannelName>{channelName}</ChannelName>
+      <ChannelGame>{channelGame}</ChannelGame>
+    </ChannelBtn>
+  );
+};
+
+export default ChannelCircle;
+
+const ChannelBtn = styled.button<{ url?: string }>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  width: 7rem;
+  height: 7rem;
+  border: 0;
+
+  border-radius: 50%;
+
+  cursor: pointer;
+  font-size: 1.2rem;
+  color: #ffffff;
+  transition: border-radius 0.3s ease;
+
+  background: linear-gradient(to bottom, #344051 75%, #202b37 25%);
+
+  ${(prop) =>
+    prop.url &&
+    css`
+      background-image: url(${prop.url});
+      background-size: cover;
+    `}
+
+  &:hover {
+    border-radius: 30%;
+  }
+`;
+
+const ChannelName = styled.div`
+  height: 75%;
+  width: 4.5rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-weight: 900;
+  font-size: 1.2rem;
+`;
+
+const ChannelGame = styled.div`
+  width: 100%;
+  height: 25%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1rem;
+`;


### PR DESCRIPTION
## 🤠 개요
- closes: #13 
- ChannelCircle 컴포넌트를 테스트 하고 구현했어요.

## 💫 설명
- 테스트에서는 컴포넌트가 있는지, 배경 이미지가 있다면 잘 표시되는지를 확인했어요!
- 아래 스크린샷을 보면 왼쪽은 배경 이미지가 없을 때고 오른쪽은 배경 이미지가 있을 때예요. 배경 이미지가 없을 때는 괜찮은데 만약 배경 이미지가 있다면 글자 색을 배경 이미지와 다른 색상으로 설정해야 텍스트가 표시돼요!
- 따라서 배경 이미지가 있다면 배경 이미지 색상에 따라 다른 글자 색을 사용할 건지 텍스트를 안 보이게 할 건지는 추후에 논의해야 할 것 같아요!

## 📷 스크린샷 (Optional)
<img width="250" alt="1111" src="https://github.com/TheUpperPart/leaguehub-frontend/assets/100738049/ead8ebd6-3ab1-41bf-acac-18843ca75d4e">

