### PR TITLE
Feat/#32: 아이콘 컴포넌트 구현

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -13,6 +13,7 @@ const customJestConfig = {
     '^@components/(.*)$': '<rootDir>/src/components/$1',
     '^@pages/(.*)$': '<rootDir>/src/pages/$1',
     '^@mocks/(.*)$': '<rootDir>/__mocks__/$1',
+    '^@type/(.*)$': '<rootDir>/src/@types/$1',
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@emotion/react": "^11.11.0",
     "@emotion/styled": "^11.11.0",
+    "@react-icons/all-files": "^4.1.0",
     "@tanstack/react-query": "^4.29.12",
     "@tanstack/react-query-devtools": "^4.29.12",
     "axios": "^1.4.0",
@@ -36,6 +37,7 @@
     "@testing-library/react": "14.0.0",
     "@testing-library/user-event": "14.4.3",
     "@types/react": "18.0.28",
+    "@types/react-icons": "^3.0.0",
     "@types/testing-library__jest-dom": "5.14.5",
     "@typescript-eslint/eslint-plugin": "^5.59.8",
     "@typescript-eslint/parser": "^5.59.8",

--- a/src/@types/icon.ts
+++ b/src/@types/icon.ts
@@ -1,0 +1,10 @@
+export type IconKind =
+  | 'lock'
+  | 'team'
+  | 'my'
+  | 'checked'
+  | 'notChecked'
+  | 'plus'
+  | 'toggleOn'
+  | 'toggleOff'
+  | 'clock';

--- a/src/components/Icon/index.tsx
+++ b/src/components/Icon/index.tsx
@@ -1,0 +1,38 @@
+import { IconKind } from 'src/@types/icon';
+import { IconType } from 'react-icons/lib';
+import {
+  MdLock,
+  MdSupervisorAccount,
+  MdPerson,
+  MdCheckBoxOutlineBlank,
+  MdCheckBox,
+  MdAdd,
+  MdToggleOff,
+  MdToggleOn,
+  MdAccessTime,
+} from 'react-icons/md';
+
+const ICON: { [key in IconKind]: IconType } = {
+  lock: MdLock,
+  team: MdSupervisorAccount,
+  my: MdPerson,
+  checked: MdCheckBox,
+  notChecked: MdCheckBoxOutlineBlank,
+  plus: MdAdd,
+  toggleOn: MdToggleOn,
+  toggleOff: MdToggleOff,
+  clock: MdAccessTime,
+};
+
+interface IconProps {
+  kind: IconKind;
+  onClick?: () => void;
+  color?: string;
+}
+
+const Icon = ({ kind, ...props }: IconProps) => {
+  const TargetIcon = ICON[kind];
+  return <TargetIcon size={28} {...props} />;
+};
+
+export default Icon;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
     "paths": {
       "@components/*": ["src/components/*"],
       "@pages/*": ["src/pages/*"],
-      "@mocks/*": ["__mocks__/*"]
+      "@mocks/*": ["__mocks__/*"],
+      "@type/*": ["src/@types/*"]
     },
     "jsxImportSource": "@emotion/react"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -807,6 +807,11 @@
   resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-1.0.3.tgz#db9cc719191a62e7d9200f6e7bab21c5b848adca"
   integrity sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==
 
+"@react-icons/all-files@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@react-icons/all-files/-/all-files-4.1.0.tgz#477284873a0821928224b6fc84c62d2534d6650b"
+  integrity sha512-hxBI2UOuVaI3O/BhQfhtb4kcGn9ft12RWAFVMUeNjqqhLsHvFtzIkFaptBJpFDANTKoDfdVoHTKZDlwKCACbMQ==
+
 "@sinclair/typebox@^0.25.16":
   version "0.25.24"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.25.24.tgz#8c7688559979f7079aacaf31aa881c3aa410b718"
@@ -1044,6 +1049,13 @@
   integrity sha512-G2mHoTMTL4yoydITgOGwWdWMVd8sNgyEP85xVmMKAPUBwQWm9wBPQUmvbeF4V3WBY1P7mmL4BkjQ0SqUpf1snw==
   dependencies:
     "@types/react" "*"
+
+"@types/react-icons@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/react-icons/-/react-icons-3.0.0.tgz#27ca2823a6add881d06a371bfff093afc1b9c829"
+  integrity sha512-Vefs6LkLqF61vfV7AiAqls+vpR94q67gunhMueDznG+msAkrYgRxl7gYjNem/kZ+as2l2mNChmF1jRZzzQQtMg==
+  dependencies:
+    react-icons "*"
 
 "@types/react@*":
   version "18.2.8"
@@ -4002,6 +4014,11 @@ react-dom@^18.2.0:
   dependencies:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
+
+react-icons@*:
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.9.0.tgz#ba44f436a053393adb1bdcafbc5c158b7b70d2a3"
+  integrity sha512-ijUnFr//ycebOqujtqtV9PFS7JjhWg0QU6ykURVHuL4cbofvRCf3f6GMn9+fBktEFQOIVZnuAYLZdiyadRQRFg==
 
 react-is@^16.7.0:
   version "16.13.1"


### PR DESCRIPTION
## 🤠 개요

- closes: #32
- 아이콘 컴포넌트를 쉽게 사용할 수 있어요 (설명 : #9) 
<!--
- 이슈번호
- 한줄 설명
- closes: #(이슈번호 입력해주세요)
  -->

## 💫 설명
## 절대경로 문제
- src/@types 라는 디렉토리를 절대경로로 지정하는데 @types 로 절대경로를 지정하니까 문제가 생겼어요
- 문제는 아마 type 관련 라이브러리들이 '@types/...' 로 시작하기 때문에 우리도 @types 로 절대경로를 지정하니까 문제가 생기는거 같아요 그래서 @types 디렉토리는 @type 로 절대경로를 설정해줬어요
<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
