### PR TITLE
Config/#34: 로그인 전역 Context 생성

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -13,6 +13,8 @@ const customJestConfig = {
     '^@components/(.*)$': '<rootDir>/src/components/$1',
     '^@pages/(.*)$': '<rootDir>/src/pages/$1',
     '^@mocks/(.*)$': '<rootDir>/__mocks__/$1',
+    '^@contexts/(.*)$': '<rootDir>/src/contexts/$1',
+    '^@hooks/(.*)$': '<rootDir>/src/hooks/$1',
   },
 };
 

--- a/src/components/providers/LoginProvider.tsx
+++ b/src/components/providers/LoginProvider.tsx
@@ -1,0 +1,14 @@
+import { useState } from 'react';
+import LoginContext from '@contexts/login';
+
+interface LoginProviderProps {
+  children: React.ReactNode;
+}
+
+const LoginProvider = ({ children }: LoginProviderProps) => {
+  const [name, setName] = useState<string | null>(null);
+
+  return <LoginContext.Provider value={{ name, setName }}>{children}</LoginContext.Provider>;
+};
+
+export default LoginProvider;

--- a/src/contexts/login.ts
+++ b/src/contexts/login.ts
@@ -1,0 +1,10 @@
+import { createContext } from 'react';
+
+interface UserState {
+  name: string | null;
+  setName: React.Dispatch<React.SetStateAction<string | null>>;
+}
+
+const LoginContext = createContext<UserState | null>(null);
+
+export default LoginContext;

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -1,0 +1,14 @@
+import LoginContext from '@contexts/login';
+import { useContext } from 'react';
+
+const useLogin = () => {
+  const context = useContext(LoginContext);
+
+  if (!context) {
+    throw new Error('LoginContext does not exists.');
+  }
+
+  return context;
+};
+
+export default useLogin;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -3,7 +3,7 @@ import { Hydrate, QueryClient, QueryClientProvider } from '@tanstack/react-query
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import type { AppProps } from 'next/app';
 import { useState } from 'react';
-
+import LoginProvider from '@components/providers/LoginProvider';
 export default function MyApp({ Component, pageProps }: AppProps) {
   const [queryClient] = useState(() => new QueryClient());
   // if (process.env.NODE_ENV === 'development') {
@@ -14,7 +14,9 @@ export default function MyApp({ Component, pageProps }: AppProps) {
       <Hydrate state={pageProps.dehydratedState}>
         <ReactQueryDevtools initialIsOpen={false} />
         <Layout>
-          <Component {...pageProps} />;
+          <LoginProvider>
+            <Component {...pageProps} />
+          </LoginProvider>
         </Layout>
       </Hydrate>
     </QueryClientProvider>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,9 @@
     "paths": {
       "@components/*": ["src/components/*"],
       "@pages/*": ["src/pages/*"],
-      "@mocks/*": ["__mocks__/*"]
+      "@mocks/*": ["__mocks__/*"],
+      "@contexts/*": ["src/contexts/*"],
+      "@hooks/*": ["src/hooks/*"]
     },
     "jsxImportSource": "@emotion/react"
   },


### PR DESCRIPTION
## 🤠 개요

- closes: #34 
- 로그인 됐을때 받는 데이터를 서버 상태 관리보단 클라이언트 상태 관리를 이용하는게 좋을거 같아서 Context 를 만들었어요
- 로그인했을때 어떤 데이터를 받을지 몰라서 일단 이름만 설정하도록 넣었어요
- Context 를 쉽게 사용할 수 있도록 useLogin 이라는 커스텀 훅을 만들었어요

<!--
- 이슈번호
- 한줄 설명
- closes: #(이슈번호 입력해주세요)
  -->

## 💫 설명
Provider를 루트 근처 최상단에 배치했기에 해당 컨텍스트를 사용하려면 아래와 같이 간단하게 사용할 수 있어요!
`const { name, setName } = useLogin();`

## 주의할점
Context 는 리액트훅이라서 서버사이드에서는 동작하지 않아요 그 말은 즉 전역 컨텍스트값을 바꾸고 쓰려면 클라이언트에서 useRouter() 또는 Link 로 CSR 을 이용해야 전역 상태값을 정상적으로 사용할 수 있어요

## 알게된 점
테스트를 해보니 pages/index.tsx 에서 useRouter.push('/test') 를 이용하면 localhost:3000/ 에 접속하니 /test 에 해당하는 컴포넌트(자바스크립트) 파일까지 가져오는것을 확인할 수 있었어요!
<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
