### PR TITLE
Test/#27: 브라우저에서 MSW 적용

### DIFF
--- a/__mocks__/handlers/testHandlers.ts
+++ b/__mocks__/handlers/testHandlers.ts
@@ -1,7 +1,8 @@
 import { rest } from 'msw';
+import { SERVER_URL } from '@config/index';
 
 const testHandlers = [
-  rest.get('/test', (req, res, ctx) => {
+  rest.get(SERVER_URL + '/test', (req, res, ctx) => {
     return res(ctx.json('test'));
   }),
 ];

--- a/__mocks__/index.ts
+++ b/__mocks__/index.ts
@@ -1,7 +1,7 @@
 const initMockAPI = async (): Promise<void> => {
   if (typeof window === 'undefined') {
     const { server } = await import('@mocks/server');
-    server.listen();
+    server.listen({ onUnhandledRequest: 'bypass' });
   } else {
     const { worker } = await import('@mocks/browser');
     worker.start();

--- a/__test__/temporary.test.ts
+++ b/__test__/temporary.test.ts
@@ -1,10 +1,11 @@
 import axios from 'axios';
+import { SERVER_URL } from '@config/index';
 
 test('1+1은 2다.', () => {
   expect(1 + 1).toBe(2);
 });
 
 test('msw Test', async () => {
-  const res = await axios.get('/test');
+  const res = await axios.get(SERVER_URL + '/test');
   expect(res.data).toBe('test');
 });

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,6 +13,7 @@ const customJestConfig = {
     '^@components/(.*)$': '<rootDir>/src/components/$1',
     '^@pages/(.*)$': '<rootDir>/src/pages/$1',
     '^@mocks/(.*)$': '<rootDir>/__mocks__/$1',
+    '^@config/(.*)$': '<rootDir>/src/config/$1',
   },
 };
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,0 +1,7 @@
+let SERVER_URL = 'http://localhost:4000';
+
+if (process.env.NODE_ENV === 'development') {
+  SERVER_URL = 'http://localhost:8080';
+}
+
+export { SERVER_URL };

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,11 +1,11 @@
 import Layout from '@components/layout';
 import initMockAPI from '@mocks/index';
 import type { AppProps } from 'next/app';
+if (process.env.NODE_ENV === 'development') {
+  initMockAPI();
+}
 
 export default function MyApp({ Component, pageProps }: AppProps) {
-  // if (process.env.NODE_ENV === 'development') {
-  //   initMockAPI();
-  // }
   return (
     <Layout>
       <Component {...pageProps} />;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,4 +1,5 @@
 import Layout from '@components/layout';
+import initMockAPI from '@mocks/index';
 import { Hydrate, QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import type { AppProps } from 'next/app';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
     "paths": {
       "@components/*": ["src/components/*"],
       "@pages/*": ["src/pages/*"],
+      "@config/*": ["src/config/*"],
       "@mocks/*": ["__mocks__/*"]
     },
     "jsxImportSource": "@emotion/react"


### PR DESCRIPTION
## 🤠 개요

- related: #27 #28 
- 클라이언트 사이드와 서버 사이드에서 MSW 를 이용해 네트워크 통신을 가로챌 수 있어요!
- 그리고 config/index.ts 파일을 보면 일단 서버주소를 `http://localhost:4000` 으로 설정해두고 만약 개발모드면 `http://localhost:8080` 을 반환하게 설정하여 우리 테스트에 사용될 hostname 은 `http://localhost:8080` 이 될거에요
<!--
- 이슈번호
- 한줄 설명
- closes: #(이슈번호 입력해주세요)
  -->

## 💫 설명
### 사용방법
1. __mocks__/handlers 디렉토리에 어떤 요청을 가로채 mocking 할건지 handlers 를 설정합니다
2. browser.ts 는 브라우저 환경, server.ts 는 서버 환경에서 적용되게 나눠서 설정 할 수 있어요
3. 그리고 사용하면 끝~

#### getServerSideProps() 같은 서버 사이드의 요청도 MSW 를 이용해 Mocking 된 데이터를 받을 수 있어요!

## 문제 및 해결방법
### 서버 사이드
![image](https://github.com/TheUpperPart/leaguehub-frontend/assets/71641127/8d761ccb-1c19-4f52-9296-56b33d37a370)

문제 : 위 이미지와 같이 서버사이드에서 해당 주소로 API 요청을 보내는데 MSW 설정에 해당 URL 에 대한 handler 가 정의되지 않아서 생긴 문제에요 (해당 요청들은 어디서 어떻게 동작하는지 어떤 동작을 유도하는지는 못찾았어요..)

해결법 : `server.listen({ onUnhandledRequest: 'bypass' });` 서버 사이드에서 정의되지 않은 handler로 요청을 보내면 에러가 아니라 그냥 아무일도 일어나지 않도록 설정해줬어요

### 클라이언트 사이드
<img width="500" alt="image" src="https://github.com/TheUpperPart/leaguehub-frontend/assets/71641127/6b7acc57-23f1-47e6-8798-1a1f3589d40e">

문제 : 위 이미지를 보면 MSW 가 적용되기 전에 axios 요청이 보내져 에러가 났음을 확인할 수 있어요. MSW 작동방식을 찾아보니 MSW 실행은 성능을 위해 컴포넌트 렌더링과 비동기적으로 실행이 되는데 MSW 적용이 늦게되어 생긴 에러에요. 그리고 강제로 await 을 걸어 동기적으로 처리하려고 해도 _app.tsx 파일은 Jsx 파일이기에 async/await 과 같은 동기적 방식을 사용할 수가 없었어요

제가 찾아본 결과 2가지 방법이 있었어요
해결방법 1 : axios 요청을 setTimeout() 을 이용해 요청을 늦게 보내 MSW 가 정상적으로 적용되고 HTTP Request 를 보내는 방법이에요. 하지만 성능적으로 좋아보이지 않아요

**해결방법 2** : MSW 설정을 MyApp() 컴포넌트 내부에 넣는게 아니라 _app.tsx 파일 상단에 배치하여 MSW 실행을 빨리하여 컴포넌트가 렌더링되기 전에 MSW 를 실행하는 방식이에요

2번 방법이 성능면이나 개발자경험이나 여러 측면에서 좋은거 같아서 2번 방법을 채택했어요!

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
<img width="500" alt="image" src="https://github.com/TheUpperPart/leaguehub-frontend/assets/71641127/f04e0228-8e4b-48f3-8e6a-11cbd5166a5d">
