### PR TITLE
Feat/#36: 채널 사이드바 구현

### DIFF
--- a/__mocks__/browser.ts
+++ b/__mocks__/browser.ts
@@ -1,4 +1,5 @@
+import channelHandlers from '@mocks/handlers/channelHandlers';
 import testHandlers from '@mocks/handlers/testHandlers';
 import { setupWorker } from 'msw';
 
-export const worker = setupWorker(...testHandlers);
+export const worker = setupWorker(...testHandlers, ...channelHandlers);

--- a/__mocks__/handlers/channelHandlers.ts
+++ b/__mocks__/handlers/channelHandlers.ts
@@ -1,0 +1,34 @@
+import { rest } from 'msw';
+import { SERVER_URL } from '@config/index';
+import { ChannelCircleProps } from '@type/channelCircle';
+
+const getChannels: ChannelCircleProps[] = [
+  {
+    channelId: '1',
+    channelName: '부경대 총장기',
+    channelGame: 'TFT',
+  },
+  {
+    channelId: '2',
+    channelName: '부경대 총장기',
+    channelGame: 'LOL',
+  },
+  {
+    channelId: '3',
+    channelName: '부경대 총장기',
+    channelGame: 'HS',
+  },
+  {
+    channelId: '4',
+    channelName: '부경대 총장기',
+    channelGame: 'FIFA',
+  },
+];
+
+const channelHandlers = [
+  rest.get(SERVER_URL + '/api/channels', (req, res, ctx) => {
+    return res(ctx.json(getChannels));
+  }),
+];
+
+export default channelHandlers;

--- a/__mocks__/server.ts
+++ b/__mocks__/server.ts
@@ -1,4 +1,5 @@
 import { setupServer } from 'msw/node';
 import testHandlers from '@mocks/handlers/testHandlers';
+import channelHandlers from '@mocks/handlers/channelHandlers';
 
-export const server = setupServer(...testHandlers);
+export const server = setupServer(...testHandlers, ...channelHandlers);

--- a/src/components/Sidebar/ChannelBar/ChannelBar.tsx
+++ b/src/components/Sidebar/ChannelBar/ChannelBar.tsx
@@ -26,6 +26,9 @@ const ChannelBar = ({ ChannelCircles }: ChannelBarProps) => {
           />
         </div>
       ))}
+      <ChannelParticipate>
+        <CenteredIcon kind='plus' color='white' />
+      </ChannelParticipate>
     </ChannelbarContainer>
   );
 };
@@ -41,6 +44,24 @@ const ChannelbarContainer = styled.div`
   flex-direction: column;
   z-index: 10;
   overflow: auto;
+`;
+
+const ChannelParticipate = styled.button`
+  min-width: 6rem;
+  min-height: 6rem;
+  border: 0;
+  border-radius: 50%;
+  cursor: pointer;
+  position: relative;
+  margin: 0 auto;
+  background: #344051;
+`;
+
+const CenteredIcon = styled(Icon)`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
 `;
 
 export default ChannelBar;

--- a/src/components/Sidebar/ChannelBar/ChannelBar.tsx
+++ b/src/components/Sidebar/ChannelBar/ChannelBar.tsx
@@ -1,0 +1,46 @@
+import Icon from '@components/Icon';
+import ChannelCircle from '@components/Sidebar/ChannelCircle/ChannelCircle';
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import { ChannelCircleProps } from '@type/channelCircle';
+
+interface ChannelBarProps {
+  ChannelCircles: ChannelCircleProps[];
+}
+
+const ChannelBar = ({ ChannelCircles }: ChannelBarProps) => {
+  return (
+    <ChannelbarContainer>
+      {ChannelCircles.map(({ channelId, channelName, channelGame }) => (
+        <div
+          key={channelId}
+          css={css`
+            margin: 0 auto;
+            margin-bottom: 2.2rem;
+          `}
+        >
+          <ChannelCircle
+            channelId={channelId}
+            channelName={channelName}
+            channelGame={channelGame}
+          />
+        </div>
+      ))}
+    </ChannelbarContainer>
+  );
+};
+
+const ChannelbarContainer = styled.div`
+  padding: 2rem 0 5rem;
+  width: 10rem;
+  height: 100vh;
+  background-color: #141c24;
+  float: left;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  z-index: 10;
+  overflow: auto;
+`;
+
+export default ChannelBar;

--- a/src/components/Sidebar/ChannelBar/ChannelBar.tsx
+++ b/src/components/Sidebar/ChannelBar/ChannelBar.tsx
@@ -11,21 +11,22 @@ interface ChannelBarProps {
 const ChannelBar = ({ ChannelCircles }: ChannelBarProps) => {
   return (
     <ChannelbarContainer>
-      {ChannelCircles.map(({ channelId, channelName, channelGame }) => (
-        <div
-          key={channelId}
-          css={css`
-            margin: 0 auto;
-            margin-bottom: 2.2rem;
-          `}
-        >
-          <ChannelCircle
-            channelId={channelId}
-            channelName={channelName}
-            channelGame={channelGame}
-          />
-        </div>
-      ))}
+      {ChannelCircles &&
+        ChannelCircles.map(({ channelId, channelName, channelGame }) => (
+          <div
+            key={channelId}
+            css={css`
+              margin: 0 auto;
+              margin-bottom: 2.2rem;
+            `}
+          >
+            <ChannelCircle
+              channelId={channelId}
+              channelName={channelName}
+              channelGame={channelGame}
+            />
+          </div>
+        ))}
       <ChannelParticipate>
         <CenteredIcon kind='plus' color='white' />
       </ChannelParticipate>

--- a/src/components/Sidebar/ChannelBar/ChannelBar.tsx
+++ b/src/components/Sidebar/ChannelBar/ChannelBar.tsx
@@ -48,8 +48,8 @@ const ChannelbarContainer = styled.div`
 `;
 
 const ChannelParticipate = styled.button`
-  min-width: 6rem;
-  min-height: 6rem;
+  width: 6rem;
+  height: 6rem;
   border: 0;
   border-radius: 50%;
   cursor: pointer;

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -1,10 +1,29 @@
+import ChannelBar from '@components/Sidebar/ChannelBar/ChannelBar';
+import { SERVER_URL } from '@config/index';
+import { useQuery } from '@tanstack/react-query';
+import axios from 'axios';
 import { PropsWithChildren } from 'react';
 import GlobalStyle from 'src/styles/GlobalStyle';
 
+const fetchData = async () => {
+  const response = await axios.get(SERVER_URL + '/api/channels', {
+    headers: {
+      Authorization: 'User Token',
+    },
+  });
+
+  return response.data;
+};
+
 const Layout = ({ children }: PropsWithChildren) => {
+  const { data } = useQuery(['getChannels'], fetchData, {
+    staleTime: Infinity,
+    cacheTime: Infinity,
+  });
   return (
     <>
       <GlobalStyle />
+      <ChannelBar ChannelCircles={data} />
       <main>{children}</main>
     </>
   );

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -17,4 +17,14 @@ const globalCss = css`
     padding: 0;
     margin: 0;
   }
+  a {
+    text-decoration: none !important;
+  }
+  a:hover {
+    text-decoration: none !import;
+  }
+  a:visited {
+    color: inherit;
+    text-decoration: none;
+  }
 `;


### PR DESCRIPTION
## 🤠 개요

- closes: #36 
- ChannelCircle 을 담을 수 있는 채널 사이드바를 구현했어요
- 여기에는 사용되진 않았지만 Link 를 사용할 때 기존 a 스타일을 없애기 위해 전역 스타일에 일부 코드를 추가했어요
<!--
- 이슈번호
- 한줄 설명
- closes: #(이슈번호 입력해주세요)
  -->

## 💫 설명
- 간단하게 ChannelCircleProps 인터페이스의 배열값을 넣어서 사용할 수 있어요
- ~~아직 컴포넌트만 만들고 페이지에는 넣어두지 않았어요~~  페이지에 넣어서 UI 확인이 가능해요!
- 채널 상태는 자주 바뀌지 않을거 같아서 staleTime, cacheTime 을 무한으로 설정하고 채널 참가/추가 시 stale 한 상태로 만드는게 좋지 않을까 생각해서 Infinity 로 설정해뒀어요
<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
<img width="353" alt="image" src="https://github.com/TheUpperPart/leaguehub-frontend/assets/71641127/8ff85909-134f-41e8-b320-f0a9c18ff88c">

