### PR TITLE
Feat/#41: 사이드바 (게시판) 구현

### DIFF
--- a/__mocks__/browser.ts
+++ b/__mocks__/browser.ts
@@ -1,5 +1,6 @@
+import boardHandlers from '@mocks/handlers/boardHandlers';
 import channelHandlers from '@mocks/handlers/channelHandlers';
 import testHandlers from '@mocks/handlers/testHandlers';
 import { setupWorker } from 'msw';
 
-export const worker = setupWorker(...testHandlers, ...channelHandlers);
+export const worker = setupWorker(...testHandlers, ...channelHandlers, ...boardHandlers);

--- a/__mocks__/handlers/boardHandlers.ts
+++ b/__mocks__/handlers/boardHandlers.ts
@@ -1,0 +1,72 @@
+import { SERVER_URL } from '@config/index';
+import { rest } from 'msw';
+import { BoardInfo } from '@type/board';
+
+const boardHandlers = [
+  rest.get(SERVER_URL + '/api/channel/:channelid', (req, res, ctx) => {
+    const { channelid } = req.params;
+    let boardInfo: BoardInfo | undefined;
+    if (channelid === '1') {
+      boardInfo = {
+        hostName: 'host1',
+        leagueTitle: '부경대 총장기',
+        game: 'TFT',
+        participateNum: 999,
+        channels: [
+          {
+            id: '1',
+            name: '공지사항',
+          },
+        ],
+        permission: 0,
+      };
+    } else if (channelid === '2') {
+      boardInfo = {
+        hostName: 'host2',
+        leagueTitle: '부산대 총장기',
+        game: 'LOL',
+        participateNum: 11,
+        channels: [
+          {
+            id: '1',
+            name: '리그 공지사항',
+          },
+          {
+            id: '2',
+            name: '참여자 규칙',
+          },
+          {
+            id: '3',
+            name: '참여하기',
+          },
+        ],
+        permission: 1,
+      };
+    } else {
+      boardInfo = {
+        hostName: 'host3',
+        leagueTitle: '동의대 총장기',
+        game: 'HS',
+        participateNum: 216,
+        channels: [
+          {
+            id: '1',
+            name: '리그 공지사항',
+          },
+          {
+            id: '2',
+            name: '참여자 규칙',
+          },
+          {
+            id: '3',
+            name: '참여하기',
+          },
+        ],
+        permission: 1,
+      };
+    }
+    return res(ctx.json(boardInfo));
+  }),
+];
+
+export default boardHandlers;

--- a/__mocks__/handlers/boardHandlers.ts
+++ b/__mocks__/handlers/boardHandlers.ts
@@ -5,7 +5,7 @@ import { BoardInfo } from '@type/board';
 const boardHandlers = [
   rest.get(SERVER_URL + '/api/channel/:channelid', (req, res, ctx) => {
     const { channelid } = req.params;
-    let boardInfo: BoardInfo | undefined;
+    let boardInfo: BoardInfo;
     if (channelid === '1') {
       boardInfo = {
         hostName: 'host1',

--- a/__mocks__/server.ts
+++ b/__mocks__/server.ts
@@ -1,5 +1,6 @@
 import { setupServer } from 'msw/node';
 import testHandlers from '@mocks/handlers/testHandlers';
 import channelHandlers from '@mocks/handlers/channelHandlers';
+import boardHandlers from '@mocks/handlers/boardHandlers';
 
-export const server = setupServer(...testHandlers, ...channelHandlers);
+export const server = setupServer(...testHandlers, ...channelHandlers, ...boardHandlers);

--- a/__test__/components/Sidebar/BoardBar/BoardBar.test.tsx
+++ b/__test__/components/Sidebar/BoardBar/BoardBar.test.tsx
@@ -1,0 +1,36 @@
+import BoardBar from '@components/Sidebar/BoardBar/BoardBar';
+import { render, screen } from '@testing-library/react';
+
+jest.mock('@tanstack/react-query', () => ({
+  useQuery: jest.fn().mockImplementation(() => {
+    const data = {
+      hostName: 'host1',
+      leagueTitle: '부경대 총장기',
+      game: 'TFT',
+      participateNum: 999,
+      channels: [
+        {
+          id: '1',
+          name: '공지사항',
+        },
+      ],
+      permission: 0,
+    };
+    const isLoading = false;
+    const error = {};
+    return { data, isLoading, error };
+  }),
+}));
+
+describe('채널 게시판 테스트', () => {
+  it('렌더링 테스트', async () => {
+    render(<BoardBar channelId='1' />);
+    const hostName = await screen.findByText('host1');
+    const leagueTitle = await screen.findByText('부경대 총장기');
+    const game = await screen.findByText('TFT');
+
+    expect(hostName).toBeInTheDocument();
+    expect(leagueTitle).toBeInTheDocument();
+    expect(game).toBeInTheDocument();
+  });
+});

--- a/__test__/components/Sidebar/BoardBar/BoardBar.test.tsx
+++ b/__test__/components/Sidebar/BoardBar/BoardBar.test.tsx
@@ -1,5 +1,7 @@
 import BoardBar from '@components/Sidebar/BoardBar/BoardBar';
 import { render, screen } from '@testing-library/react';
+import React from 'react';
+import userEvent from '@testing-library/user-event';
 
 jest.mock('@tanstack/react-query', () => ({
   useQuery: jest.fn().mockImplementation(() => {
@@ -26,6 +28,13 @@ jest.mock('@tanstack/react-query', () => ({
   }),
 }));
 
+const mockSetState = jest.fn();
+
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useState: (initial: string) => [initial, mockSetState],
+}));
+
 describe('채널 게시판 테스트', () => {
   it('헤더 렌더링 테스트', async () => {
     render(<BoardBar channelId='1' />);
@@ -47,5 +56,16 @@ describe('채널 게시판 테스트', () => {
     expect(leagueNoti).toBeInTheDocument();
     expect(leagueRules).toBeInTheDocument();
     expect(addNoti).toBeInTheDocument();
+  });
+
+  it('게시판 바디 클릭된 li 상태 변경 테스트', async () => {
+    render(<BoardBar channelId='1' />);
+    const boardElements = screen.getAllByRole('listitem');
+
+    await userEvent.click(boardElements[0]);
+    expect(mockSetState).toHaveBeenCalledWith('1');
+
+    await userEvent.click(boardElements[1]);
+    expect(mockSetState).toHaveBeenCalledWith('2');
   });
 });

--- a/__test__/components/Sidebar/BoardBar/BoardBar.test.tsx
+++ b/__test__/components/Sidebar/BoardBar/BoardBar.test.tsx
@@ -13,6 +13,10 @@ jest.mock('@tanstack/react-query', () => ({
           id: '1',
           name: '공지사항',
         },
+        {
+          id: '2',
+          name: '참여자 규칙',
+        },
       ],
       permission: 0,
     };
@@ -23,7 +27,7 @@ jest.mock('@tanstack/react-query', () => ({
 }));
 
 describe('채널 게시판 테스트', () => {
-  it('렌더링 테스트', async () => {
+  it('헤더 렌더링 테스트', async () => {
     render(<BoardBar channelId='1' />);
     const hostName = await screen.findByText('host1');
     const leagueTitle = await screen.findByText('부경대 총장기');
@@ -32,5 +36,16 @@ describe('채널 게시판 테스트', () => {
     expect(hostName).toBeInTheDocument();
     expect(leagueTitle).toBeInTheDocument();
     expect(game).toBeInTheDocument();
+  });
+
+  it('바디 (공지사항, 규칙 등) 게시판 내용 렌더링 테스트', async () => {
+    render(<BoardBar channelId='1' />);
+    const leagueNoti = await screen.findByText('공지사항');
+    const leagueRules = await screen.findByText('참여자 규칙');
+    const addNoti = await screen.findByText('공지 추가하기');
+
+    expect(leagueNoti).toBeInTheDocument();
+    expect(leagueRules).toBeInTheDocument();
+    expect(addNoti).toBeInTheDocument();
   });
 });

--- a/__test__/components/Sidebar/BoardBar/BoardBar.test.tsx
+++ b/__test__/components/Sidebar/BoardBar/BoardBar.test.tsx
@@ -27,7 +27,7 @@ describe('채널 게시판 테스트', () => {
     render(<BoardBar channelId='1' />);
     const hostName = await screen.findByText('host1');
     const leagueTitle = await screen.findByText('부경대 총장기');
-    const game = await screen.findByText('TFT');
+    const game = await screen.findByText('롤토체스');
 
     expect(hostName).toBeInTheDocument();
     expect(leagueTitle).toBeInTheDocument();

--- a/src/@types/board.ts
+++ b/src/@types/board.ts
@@ -1,0 +1,11 @@
+export interface BoardInfo {
+  hostName: string;
+  leagueTitle: string;
+  game: string;
+  participateNum: number;
+  channels: {
+    id: string;
+    name: string;
+  }[];
+  permission: number;
+}

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -16,7 +16,7 @@ const Header = () => {
     <Headers>
       <Container>
         <LoginBtn onClick={handleLink}>
-          <Icon kind='my' color='white' />
+          <Icon kind='my' color='white' size={24} />
           <Text>로그인</Text>
         </LoginBtn>
       </Container>

--- a/src/components/Icon/index.tsx
+++ b/src/components/Icon/index.tsx
@@ -28,11 +28,12 @@ interface IconProps {
   kind: IconKind;
   onClick?: () => void;
   color?: string;
+  size?: string | number;
 }
 
 const Icon = ({ kind, ...props }: IconProps) => {
   const TargetIcon = ICON[kind];
-  return <TargetIcon size={28} {...props} />;
+  return <TargetIcon {...props} />;
 };
 
 export default Icon;

--- a/src/components/Sidebar/BoardBar/BoardBar.tsx
+++ b/src/components/Sidebar/BoardBar/BoardBar.tsx
@@ -1,0 +1,47 @@
+import BoardHeader from '@components/Sidebar/BoardBar/BoardHeader';
+import { SERVER_URL } from '@config/index';
+import styled from '@emotion/styled';
+import { useQuery } from '@tanstack/react-query';
+import { BoardInfo } from '@type/board';
+import axios from 'axios';
+
+const fetchData = async (channelId: string) => {
+  const response = await axios.get<BoardInfo>(SERVER_URL + '/api/channel/' + channelId, {
+    headers: {
+      Authorization: 'User Token',
+    },
+  });
+  return response.data;
+};
+
+const BoardBar = ({ channelId }: { channelId: string }) => {
+  const { data } = useQuery(['getBoard', channelId], () => fetchData(channelId), {
+    staleTime: Infinity,
+    cacheTime: Infinity,
+  });
+
+  return (
+    <Container>
+      {data && (
+        <div>
+          <BoardHeader
+            hostname={data.hostName}
+            leagueTitle={data.leagueTitle}
+            game={data.game}
+            participateNum={data.participateNum}
+          />
+        </div>
+      )}
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  width: 22rem;
+  height: 100vh;
+  background-color: #202b37;
+  overflow: auto;
+  padding: 5%;
+`;
+
+export default BoardBar;

--- a/src/components/Sidebar/BoardBar/BoardBar.tsx
+++ b/src/components/Sidebar/BoardBar/BoardBar.tsx
@@ -39,11 +39,10 @@ const BoardBar = ({ channelId }: { channelId: string }) => {
 };
 
 const Container = styled.div`
-  width: 22rem;
+  width: 24rem;
   height: 100vh;
   background-color: #202b37;
   overflow: auto;
-  padding: 1%;
 `;
 
 export default BoardBar;

--- a/src/components/Sidebar/BoardBar/BoardBar.tsx
+++ b/src/components/Sidebar/BoardBar/BoardBar.tsx
@@ -1,3 +1,4 @@
+import BoardBody from '@components/Sidebar/BoardBar/BoardBody';
 import BoardHeader from '@components/Sidebar/BoardBar/BoardHeader';
 import { SERVER_URL } from '@config/index';
 import styled from '@emotion/styled';
@@ -30,6 +31,7 @@ const BoardBar = ({ channelId }: { channelId: string }) => {
             game={data.game}
             participateNum={data.participateNum}
           />
+          <BoardBody channels={data.channels} />
         </div>
       )}
     </Container>

--- a/src/components/Sidebar/BoardBar/BoardBar.tsx
+++ b/src/components/Sidebar/BoardBar/BoardBar.tsx
@@ -26,15 +26,13 @@ const BoardBar = ({ channelId }: { channelId: string }) => {
     <Container>
       {data && (
         <ContentContainer>
-          <div>
-            <BoardHeader
-              hostname={data.hostName}
-              leagueTitle={data.leagueTitle}
-              game={data.game}
-              participateNum={data.participateNum}
-            />
-            <BoardBody channels={data.channels} />
-          </div>
+          <BoardHeader
+            hostname={data.hostName}
+            leagueTitle={data.leagueTitle}
+            game={data.game}
+            participateNum={data.participateNum}
+          />
+          <BoardBody channels={data.channels} />
         </ContentContainer>
       )}
       <FooterContainer>

--- a/src/components/Sidebar/BoardBar/BoardBar.tsx
+++ b/src/components/Sidebar/BoardBar/BoardBar.tsx
@@ -1,4 +1,5 @@
 import BoardBody from '@components/Sidebar/BoardBar/BoardBody';
+import BoardFooter from '@components/Sidebar/BoardBar/BoardFooter';
 import BoardHeader from '@components/Sidebar/BoardBar/BoardHeader';
 import { SERVER_URL } from '@config/index';
 import styled from '@emotion/styled';
@@ -24,16 +25,21 @@ const BoardBar = ({ channelId }: { channelId: string }) => {
   return (
     <Container>
       {data && (
-        <div>
-          <BoardHeader
-            hostname={data.hostName}
-            leagueTitle={data.leagueTitle}
-            game={data.game}
-            participateNum={data.participateNum}
-          />
-          <BoardBody channels={data.channels} />
-        </div>
+        <ContentContainer>
+          <div>
+            <BoardHeader
+              hostname={data.hostName}
+              leagueTitle={data.leagueTitle}
+              game={data.game}
+              participateNum={data.participateNum}
+            />
+            <BoardBody channels={data.channels} />
+          </div>
+        </ContentContainer>
       )}
+      <FooterContainer>
+        <BoardFooter channelId={channelId} />
+      </FooterContainer>
     </Container>
   );
 };
@@ -43,6 +49,20 @@ const Container = styled.div`
   height: 100vh;
   background-color: #202b37;
   overflow: auto;
+  position: relative;
+`;
+
+const ContentContainer = styled.div`
+  height: 96%;
+  padding-bottom: 3rem;
+`;
+
+const FooterContainer = styled.div`
+  position: sticky;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 3rem;
 `;
 
 export default BoardBar;

--- a/src/components/Sidebar/BoardBar/BoardBar.tsx
+++ b/src/components/Sidebar/BoardBar/BoardBar.tsx
@@ -41,7 +41,7 @@ const Container = styled.div`
   height: 100vh;
   background-color: #202b37;
   overflow: auto;
-  padding: 5%;
+  padding: 1%;
 `;
 
 export default BoardBar;

--- a/src/components/Sidebar/BoardBar/BoardBody.tsx
+++ b/src/components/Sidebar/BoardBar/BoardBody.tsx
@@ -31,6 +31,7 @@ const BoardBody = ({ channels }: Pick<BoardInfo, 'channels'>) => {
         공지 추가하기
         <Icon kind='plus' color='#637083' size='1.6rem' />
       </Wrapper>
+      <Boarder></Boarder>
     </Container>
   );
 };
@@ -39,15 +40,19 @@ export default BoardBody;
 
 const Container = styled.ul`
   color: white;
-  border-bottom: solid 1px #344051;
 `;
 
 const Wrapper = styled.li<{ isSelected: boolean }>`
   font-size: 1.5rem;
-  padding: 1.5rem 0 1.5rem;
+  padding: 1.5rem 1.5rem 1.5rem 1.5rem;
   display: flex;
   justify-content: space-between;
   align-items: center;
   cursor: pointer;
   ${({ isSelected }) => isSelected && `background-color: #39587E`}
+`;
+
+const Boarder = styled.div`
+  margin: 1.4rem;
+  border-bottom: solid 1px #344051;
 `;

--- a/src/components/Sidebar/BoardBar/BoardBody.tsx
+++ b/src/components/Sidebar/BoardBar/BoardBody.tsx
@@ -49,7 +49,11 @@ const Wrapper = styled.li<{ isSelected: boolean }>`
   justify-content: space-between;
   align-items: center;
   cursor: pointer;
-  ${({ isSelected }) => isSelected && `background-color: #39587E`}
+  &:hover {
+    background-color: #39587e;
+  }
+
+  ${({ isSelected }) => isSelected && `background-color: #39587E`};
 `;
 
 const Boarder = styled.div`

--- a/src/components/Sidebar/BoardBar/BoardBody.tsx
+++ b/src/components/Sidebar/BoardBar/BoardBody.tsx
@@ -1,17 +1,26 @@
 import styled from '@emotion/styled';
 import { BoardInfo } from '@type/board';
+import { MouseEventHandler, useEffect, useState } from 'react';
 
 const BoardBody = ({ channels }: Pick<BoardInfo, 'channels'>) => {
-  const addNoti = {
-    id: 'add',
-    name: '공지 추가하기',
+  const [selected, setSelected] = useState<string>('');
+
+  const onClick: MouseEventHandler<HTMLElement> = (e) => {
+    if (e.target !== e.currentTarget) return;
+    const clickedId = e.currentTarget.dataset.id;
+    if (clickedId) {
+      setSelected(clickedId);
+    }
   };
-  channels.push(addNoti);
+
   return (
     <Container>
       {channels.map((channel) => (
-        <Wrapper key={channel.id}>{channel.name}</Wrapper>
+        <Wrapper key={channel.id} data-id={channel.id} onClick={onClick}>
+          {channel.name}
+        </Wrapper>
       ))}
+      <Wrapper>공지 추가하기</Wrapper>
     </Container>
   );
 };

--- a/src/components/Sidebar/BoardBar/BoardBody.tsx
+++ b/src/components/Sidebar/BoardBar/BoardBody.tsx
@@ -1,3 +1,4 @@
+import Icon from '@components/Icon';
 import styled from '@emotion/styled';
 import { BoardInfo } from '@type/board';
 import { MouseEventHandler, useEffect, useState } from 'react';
@@ -23,9 +24,13 @@ const BoardBody = ({ channels }: Pick<BoardInfo, 'channels'>) => {
           isSelected={channel.id === selected}
         >
           {channel.name}
+          <Icon kind='lock' color='#637083' size='1.5rem' />
         </Wrapper>
       ))}
-      <Wrapper isSelected={false}>공지 추가하기</Wrapper>
+      <Wrapper isSelected={false}>
+        공지 추가하기
+        <Icon kind='plus' color='#637083' size='1.6rem' />
+      </Wrapper>
     </Container>
   );
 };
@@ -34,8 +39,15 @@ export default BoardBody;
 
 const Container = styled.ul`
   color: white;
+  border-bottom: solid 1px #344051;
 `;
 
 const Wrapper = styled.li<{ isSelected: boolean }>`
+  font-size: 1.5rem;
+  padding: 1.5rem 0 1.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: pointer;
   ${({ isSelected }) => isSelected && `background-color: #39587E`}
 `;

--- a/src/components/Sidebar/BoardBar/BoardBody.tsx
+++ b/src/components/Sidebar/BoardBar/BoardBody.tsx
@@ -1,0 +1,25 @@
+import styled from '@emotion/styled';
+import { BoardInfo } from '@type/board';
+
+const BoardBody = ({ channels }: Pick<BoardInfo, 'channels'>) => {
+  const addNoti = {
+    id: 'add',
+    name: '공지 추가하기',
+  };
+  channels.push(addNoti);
+  return (
+    <Container>
+      {channels.map((channel) => (
+        <Wrapper key={channel.id}>{channel.name}</Wrapper>
+      ))}
+    </Container>
+  );
+};
+
+export default BoardBody;
+
+const Container = styled.ul`
+  color: white;
+`;
+
+const Wrapper = styled.li``;

--- a/src/components/Sidebar/BoardBar/BoardBody.tsx
+++ b/src/components/Sidebar/BoardBar/BoardBody.tsx
@@ -16,11 +16,16 @@ const BoardBody = ({ channels }: Pick<BoardInfo, 'channels'>) => {
   return (
     <Container>
       {channels.map((channel) => (
-        <Wrapper key={channel.id} data-id={channel.id} onClick={onClick}>
+        <Wrapper
+          key={channel.id}
+          data-id={channel.id}
+          onClick={onClick}
+          isSelected={channel.id === selected}
+        >
           {channel.name}
         </Wrapper>
       ))}
-      <Wrapper>공지 추가하기</Wrapper>
+      <Wrapper isSelected={false}>공지 추가하기</Wrapper>
     </Container>
   );
 };
@@ -31,4 +36,6 @@ const Container = styled.ul`
   color: white;
 `;
 
-const Wrapper = styled.li``;
+const Wrapper = styled.li<{ isSelected: boolean }>`
+  ${({ isSelected }) => isSelected && `background-color: #39587E`}
+`;

--- a/src/components/Sidebar/BoardBar/BoardFooter.tsx
+++ b/src/components/Sidebar/BoardBar/BoardFooter.tsx
@@ -1,0 +1,14 @@
+import styled from '@emotion/styled';
+
+const BoardFooter = ({ channelId }: { channelId: string }) => {
+  return <Container>리그 참여하기</Container>;
+};
+
+const Container = styled.div`
+  color: white;
+  font-size: 1.5rem;
+  text-align: center;
+  cursor: pointer;
+`;
+
+export default BoardFooter;

--- a/src/components/Sidebar/BoardBar/BoardHeader.tsx
+++ b/src/components/Sidebar/BoardBar/BoardHeader.tsx
@@ -1,0 +1,31 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+interface BoardHeaderProps {
+  hostname: string;
+  leagueTitle: string;
+  game: string;
+  participateNum: number;
+}
+
+const BoardHeader = ({ hostname, leagueTitle, game, participateNum }: BoardHeaderProps) => {
+  return (
+    <Container>
+      <p>개최자 </p>
+      {hostname}
+      <div>{leagueTitle}</div>
+      <div
+        css={css`
+          margin: 0 auto;
+        `}
+      >
+        {game}
+      </div>
+      <div>{participateNum}</div>
+    </Container>
+  );
+};
+
+export default BoardHeader;
+
+const Container = styled.div``;

--- a/src/components/Sidebar/BoardBar/BoardHeader.tsx
+++ b/src/components/Sidebar/BoardBar/BoardHeader.tsx
@@ -1,3 +1,4 @@
+import Icon from '@components/Icon';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -41,7 +42,13 @@ const BoardHeader = ({ hostname, leagueTitle, game, participateNum }: BoardHeade
         <TitleContainer>{leagueTitle}</TitleContainer>
         <GameNameWrapper>{getGameFullName(game)}</GameNameWrapper>
       </Wrapper>
-      <div>{participateNum}</div>
+      <ParticipateWrapper>
+        <span>참여자(팀)</span>
+        <ParticipateBox>
+          <Icon kind='team' color='#637083' />
+          {participateNum}
+        </ParticipateBox>
+      </ParticipateWrapper>
     </Container>
   );
 };
@@ -82,4 +89,19 @@ const TitleContainer = styled.div`
 const GameNameWrapper = styled.div`
   text-align: center;
   padding: 1rem 0 1rem;
+`;
+
+const ParticipateWrapper = styled.div`
+  padding: 1rem 0 1rem;
+  border-bottom: solid 1px #344051;
+`;
+
+const ParticipateBox = styled.div`
+  background-color: #344051;
+  padding: 2% 3% 2% 3%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-radius: 0.5rem;
+  margin: 1rem 0 1rem;
 `;

--- a/src/components/Sidebar/BoardBar/BoardHeader.tsx
+++ b/src/components/Sidebar/BoardBar/BoardHeader.tsx
@@ -56,6 +56,7 @@ const BoardHeader = ({ hostname, leagueTitle, game, participateNum }: BoardHeade
 export default BoardHeader;
 
 const Container = styled.div`
+  padding: 1.4rem;
   color: white;
   font-size: 1.3rem;
 `;
@@ -98,7 +99,7 @@ const ParticipateWrapper = styled.div`
 
 const ParticipateBox = styled.div`
   background-color: #344051;
-  padding: 2% 3% 2% 3%;
+  padding: 1rem 1rem 1rem 1rem;
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/src/components/Sidebar/BoardBar/BoardHeader.tsx
+++ b/src/components/Sidebar/BoardBar/BoardHeader.tsx
@@ -8,19 +8,39 @@ interface BoardHeaderProps {
   participateNum: number;
 }
 
+type GameFullName = '리그오브레전드' | '롤토체스' | '피파' | '하스스톤' | '??';
+
+const getGameFullName = (game: string): GameFullName => {
+  let gameFullName: GameFullName;
+  switch (game) {
+    case 'LOL':
+      gameFullName = '리그오브레전드';
+      break;
+    case 'TFT':
+      gameFullName = '롤토체스';
+      break;
+    case 'FIFA':
+      gameFullName = '피파';
+      break;
+    case 'HS':
+      gameFullName = '하스스톤';
+      break;
+    default:
+      gameFullName = '??';
+  }
+
+  return gameFullName;
+};
+
 const BoardHeader = ({ hostname, leagueTitle, game, participateNum }: BoardHeaderProps) => {
   return (
     <Container>
-      <p>개최자 </p>
-      {hostname}
-      <div>{leagueTitle}</div>
-      <div
-        css={css`
-          margin: 0 auto;
-        `}
-      >
-        {game}
-      </div>
+      <Wrapper>
+        <span css={labelStyle}>개최자 </span>
+        <span css={hostnameStyle}>{hostname}</span>
+        <TitleContainer>{leagueTitle}</TitleContainer>
+        <GameNameWrapper>{getGameFullName(game)}</GameNameWrapper>
+      </Wrapper>
       <div>{participateNum}</div>
     </Container>
   );
@@ -28,4 +48,38 @@ const BoardHeader = ({ hostname, leagueTitle, game, participateNum }: BoardHeade
 
 export default BoardHeader;
 
-const Container = styled.div``;
+const Container = styled.div`
+  color: white;
+  font-size: 1.3rem;
+`;
+
+const Wrapper = styled.div`
+  border-bottom: solid 1px #344051;
+`;
+
+const labelStyle = css`
+  color: #ced2da;
+  font-size: 1.2rem;
+`;
+
+const hostnameStyle = css`
+  font-size: 1.5rem;
+  font-weight: semi-bold;
+`;
+
+const TitleContainer = styled.div`
+  width: 100%;
+  height: 3rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #637083;
+  border-radius: 0.5rem;
+  margin-top: 3px;
+  font-weight: bold;
+`;
+
+const GameNameWrapper = styled.div`
+  text-align: center;
+  padding: 1rem 0 1rem;
+`;

--- a/src/components/Sidebar/BoardBar/BoardHeader.tsx
+++ b/src/components/Sidebar/BoardBar/BoardHeader.tsx
@@ -45,7 +45,7 @@ const BoardHeader = ({ hostname, leagueTitle, game, participateNum }: BoardHeade
       <ParticipateWrapper>
         <span>참여자(팀)</span>
         <ParticipateBox>
-          <Icon kind='team' color='#637083' />
+          <Icon kind='team' color='#637083' size='2rem' />
           {participateNum}
         </ParticipateBox>
       </ParticipateWrapper>

--- a/src/components/Sidebar/ChannelBar/ChannelBar.tsx
+++ b/src/components/Sidebar/ChannelBar/ChannelBar.tsx
@@ -31,7 +31,7 @@ const ChannelBar = ({ ChannelCircles, ChannelHandler }: ChannelBarProps) => {
           </div>
         ))}
       <ChannelParticipate>
-        <CenteredIcon kind='plus' color='white' />
+        <CenteredIcon kind='plus' color='white' size={24} />
       </ChannelParticipate>
     </ChannelbarContainer>
   );

--- a/src/components/Sidebar/ChannelBar/ChannelBar.tsx
+++ b/src/components/Sidebar/ChannelBar/ChannelBar.tsx
@@ -3,18 +3,21 @@ import ChannelCircle from '@components/Sidebar/ChannelCircle/ChannelCircle';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { ChannelCircleProps } from '@type/channelCircle';
+import React from 'react';
 
 interface ChannelBarProps {
   ChannelCircles: ChannelCircleProps[];
+  ChannelHandler: (channelId: string) => void;
 }
 
-const ChannelBar = ({ ChannelCircles }: ChannelBarProps) => {
+const ChannelBar = ({ ChannelCircles, ChannelHandler }: ChannelBarProps) => {
   return (
     <ChannelbarContainer>
       {ChannelCircles &&
         ChannelCircles.map(({ channelId, channelName, channelGame }) => (
           <div
             key={channelId}
+            onClick={() => ChannelHandler(channelId)}
             css={css`
               margin: 0 auto;
               margin-bottom: 2.2rem;

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -3,9 +3,10 @@ import { SERVER_URL } from '@config/index';
 import styled from '@emotion/styled';
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, useState } from 'react';
 import GlobalStyle from 'src/styles/GlobalStyle';
 import Header from './Header/Header';
+import BoardBar from '@components/Sidebar/BoardBar/BoardBar';
 
 const fetchData = async () => {
   const response = await axios.get(SERVER_URL + '/api/channels', {
@@ -18,15 +19,22 @@ const fetchData = async () => {
 };
 
 const Layout = ({ children }: PropsWithChildren) => {
+  const [selectedChannel, setSelectedChannel] = useState<string>('0');
   const { data } = useQuery(['getChannels'], fetchData, {
     staleTime: Infinity,
     cacheTime: Infinity,
   });
+
+  const updateSelectedChannel = (channelId: string) => {
+    setSelectedChannel(channelId);
+  };
+
   return (
     <>
       <GlobalStyle />
       <CommonLayout>
-        <ChannelBar ChannelCircles={data} />
+        <ChannelBar ChannelCircles={data} ChannelHandler={updateSelectedChannel} />
+        <BoardBar channelId={selectedChannel} />
         <Wrapper>
           <Header />
           <main>{children}</main>

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -27,4 +27,8 @@ const globalCss = css`
     color: inherit;
     text-decoration: none;
   }
+  ul,
+  li {
+    list-style: none;
+  }
 `;


### PR DESCRIPTION
## 🤠 개요

- closes: #41 
- 게시판을 구현했는데 커밋이 많아요..
<!--
- 이슈번호
- 한줄 설명
- closes: #(이슈번호 입력해주세요)
  -->

## 💫 설명
## 만들어진 기능
- 채널 선택 시 선택된 채널을 관리하는 기능
- 게시판 선택 시 선택된 게시판을 관리하는 기능

## 안만들어진 기능
- 공지 추가하기/리그 참여하기 의 경우 모달창을 이용할거 같아서 클릭 이벤트가 아직 아무것도 없어요
- 게시판 리스트 (공지사항, 참여자규칙)를 클릭했을 때 id 값을 이용해 선택 상태를 관리했고 페이지(URL) 변경은 구현 안했어요
- 해당 리그를 참여하는 사람(팀)을 클릭했을 때 이벤트도 아직 없어요

## 아쉬운점
- 작업의 볼륨이 커서 해당 이슈에 대해 이슈를 또 나눠서 작업한 후 squash merge 하는게 더 괜찮을거 같다는 생각이 들었어요
<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
참고사항 : 3번째 채널과 4번째 채널은 같은 데이터를 이용하고 있어요

https://github.com/TheUpperPart/leaguehub-frontend/assets/71641127/2057e1bd-a7d0-4e73-92b9-78d2da9af495

