### PR TITLE
Feat/#43 axios 인스턴스 생성

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -17,6 +17,7 @@ const customJestConfig = {
     '^@contexts/(.*)$': '<rootDir>/src/contexts/$1',
     '^@hooks/(.*)$': '<rootDir>/src/hooks/$1',
     '^@type/(.*)$': '<rootDir>/src/@types/$1',
+    '^@apis/(.*)$': '<rootDir>/src/apis/$1',
   },
 };
 

--- a/src/apis/authAPI.ts
+++ b/src/apis/authAPI.ts
@@ -1,0 +1,20 @@
+import { SERVER_URL } from '@config/index';
+import axios from 'axios';
+
+const authAPI = axios.create({
+  baseURL: SERVER_URL,
+});
+
+// api 요청하기 전 수행
+authAPI.interceptors.request.use((config) => {
+  const accessToken = localStorage.getItem('accessToken');
+
+  // 액세스 토큰이 존재할 때만 탑재
+  if (accessToken) {
+    config.headers['Authorization'] = `Bearer ${localStorage.getItem('accessToken')}`;
+  }
+
+  return config;
+});
+
+export default authAPI;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,10 +20,10 @@
       "@pages/*": ["src/pages/*"],
       "@config/*": ["src/config/*"],
       "@mocks/*": ["__mocks__/*"],
-      "@mocks/*": ["__mocks__/*"],
       "@contexts/*": ["src/contexts/*"],
       "@hooks/*": ["src/hooks/*"],
-      "@type/*": ["src/@types/*"]
+      "@type/*": ["src/@types/*"],
+      "@apis/*": ["src/apis/*"]
     },
     "jsxImportSource": "@emotion/react"
   },


### PR DESCRIPTION
## 🤠 개요

- closes: #43 
- axios 인스턴스를 생성해서 baseURL과 accessToken을 자동 탑재해서 중복되는 코드를 줄일 수 있어요!
- apis 폴더를 절대경로로 사용할 수 있도록 tsconfig와 jest.config를 수정했어요

## 💫 설명
아래와 같이 사용하면 돼요.
SERVER_URL은 baseURL로 설정되어 있어서 그 이후 url만 작성하면 됩니다!
```typescript
const testAPI = async () => {
  const res = await authAPI({
    method: 'get',
    url: '/api/profile',
  });
  return res.data;
};
```



## 📷 스크린샷 (Optional)
개발자 도구의 네트워크 탭을 활용해서 accessToken이 자동으로 탑재됨을 확인했어요!
<img width="455" alt="토큰탑재" src="https://github.com/TheUpperPart/leaguehub-frontend/assets/100738049/dd788320-8c49-4058-8304-802452ddade7">

