### PR TITLE
Feat: 커스텀 버튼 생성

### DIFF
--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -10,8 +10,6 @@ interface ButtonProps {
   padding?: number;
   margin?: number;
   borderRadius?: number;
-
-  border?: string;
 }
 
 const Button = ({ onClick, children, type = 'button', ...rest }: ButtonProps) => {
@@ -30,7 +28,7 @@ const CustomBtn = styled.button<ButtonProps>`
 
   border-radius: ${(prop) => (prop.borderRadius ? prop.borderRadius + 'rem' : '1rem')};
 
-  border: ${(prop) => (prop.border ? prop.border : 'none')};
+  border: none;
 
   background-color: #202b37;
   border-radius: 1rem;

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,0 +1,41 @@
+import styled from '@emotion/styled';
+
+interface ButtonProps {
+  type?: 'button' | 'submit' | 'reset';
+  onClick?: () => void;
+  children?: React.ReactNode;
+
+  width?: number;
+  height?: number;
+  padding?: number;
+  margin?: number;
+  borderRadius?: number;
+
+  border?: string;
+}
+
+const Button = ({ onClick, children, type = 'button', ...rest }: ButtonProps) => {
+  return (
+    <CustomBtn onClick={onClick} type={type} {...rest}>
+      {children}
+    </CustomBtn>
+  );
+};
+
+export default Button;
+
+const CustomBtn = styled.button<ButtonProps>`
+  width: ${(prop) => (prop.width ? prop.width + 'rem' : 'auto')};
+  height: ${(prop) => (prop.width ? prop.height + 'rem' : 'auto')};
+
+  border-radius: ${(prop) => (prop.borderRadius ? prop.borderRadius + 'rem' : '1rem')};
+
+  border: ${(prop) => (prop.border ? prop.border : 'none')};
+
+  background-color: #202b37;
+  border-radius: 1rem;
+  color: #f9fafb;
+  font-size: 2rem;
+
+  cursor: pointer;
+`;


### PR DESCRIPTION
## 🤠 개요

- closes: #50 
- 전역적으로 사용할 커스텀 버튼을 하나 만들었어요
<!--
- 이슈번호
- 한줄 설명
- closes: #(이슈번호 입력해주세요)
  -->



## 💫 설명
#48  의 기능을 구현중인데 공통적으로 사용되는 버튼이 있어서 커스텀 버튼을 만들었어요.
- width, height, padding, margin, borderRadius, border를 설정할 수 있어요. (전부 rem 단위에요.)
- border의 경우 "1px solid black" 이렇게 전체를 써야해서 해당 type은 없앨까 생각중이에요!


## 📷 스크린샷 (Optional)
<img width="332" alt="dddd" src="https://github.com/TheUpperPart/leaguehub-frontend/assets/100738049/02696ab0-db1c-4214-981c-a87360f3e844">
