### PR TITLE
Feat/#62: 게시판 콘텐츠 수정하는 텍스트란 추가

### DIFF
--- a/src/components/Content/ContentModify.tsx
+++ b/src/components/Content/ContentModify.tsx
@@ -20,7 +20,12 @@ const ContentModify = ({ content, onUpdateContent }: ContentModifyProps) => {
   const textRef = useRef<HTMLTextAreaElement>(null);
 
   const handleUpdateContent = () => {
-    if (textRef.current) onUpdateContent(textRef.current.value);
+    if (textRef.current === null) alert('글자를 입력해주세요!');
+    else if (textRef.current.value.length < 5) alert('5글자 이상 입력해주세요!');
+    else {
+      const res = window.confirm('수정하겠습니까?');
+      if (res) onUpdateContent(textRef.current.value);
+    }
   };
 
   return (

--- a/src/components/Content/ContentModify.tsx
+++ b/src/components/Content/ContentModify.tsx
@@ -1,0 +1,80 @@
+import Modal from '@components/Modal';
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import { useRef, useState } from 'react';
+import { ReactMarkdown } from 'react-markdown/lib/react-markdown';
+
+interface ContentModifyProps {
+  content: string;
+}
+
+interface ContentButtonProps {
+  onClick?: () => void;
+  right: string;
+  backgroundColor: string;
+}
+
+const ContentModify = ({ content }: ContentModifyProps) => {
+  const [isPreviewModalOpen, setIsPreviewModalOpen] = useState(false);
+  const textRef = useRef<HTMLTextAreaElement>(null);
+
+  return (
+    <>
+      {isPreviewModalOpen && textRef.current && (
+        <Modal onClose={() => setIsPreviewModalOpen(false)}>
+          <div
+            css={css`
+              text-align: start;
+            `}
+          >
+            <ReactMarkdown children={textRef.current.value} />
+          </div>
+        </Modal>
+      )}
+      <InputField placeholder={'텍스트를 입력해주세요'} defaultValue={content} ref={textRef} />
+      <ContentButton right='25rem' backgroundColor='#ff0044'>
+        삭제하기
+      </ContentButton>
+      <ContentButton
+        right='15rem'
+        backgroundColor='grey'
+        onClick={() => setIsPreviewModalOpen(true)}
+      >
+        미리보기
+      </ContentButton>
+      <ContentButton right='5rem' backgroundColor='#0067a3'>
+        수정완료
+      </ContentButton>
+    </>
+  );
+};
+
+export default ContentModify;
+
+const InputField = styled.textarea`
+  width: 100%;
+  min-height: 75vh;
+  border: none;
+  resize: vertical;
+  border: 2px solid #d3d3d3;
+  outline-color: #039be5;
+  padding: 1rem;
+  border-radius: 1rem;
+  font-size: 1.5rem;
+`;
+
+const ContentButton = styled.button<ContentButtonProps>`
+  font-size: 2rem;
+  color: white;
+  position: fixed;
+  bottom: 3rem;
+  border: none;
+  padding: 1rem;
+  border-radius: 1rem;
+  &: hover {
+    cursor: pointer;
+  }
+
+  right: ${(props) => props.right};
+  background-color: ${(props) => props.backgroundColor};
+`;

--- a/src/components/Content/ContentModify.tsx
+++ b/src/components/Content/ContentModify.tsx
@@ -1,11 +1,12 @@
 import Modal from '@components/Modal';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { ReactMarkdown } from 'react-markdown/lib/react-markdown';
 
 interface ContentModifyProps {
   content: string;
+  onUpdateContent: (updatedContent: string) => void;
 }
 
 interface ContentButtonProps {
@@ -14,9 +15,13 @@ interface ContentButtonProps {
   backgroundColor: string;
 }
 
-const ContentModify = ({ content }: ContentModifyProps) => {
+const ContentModify = ({ content, onUpdateContent }: ContentModifyProps) => {
   const [isPreviewModalOpen, setIsPreviewModalOpen] = useState(false);
   const textRef = useRef<HTMLTextAreaElement>(null);
+
+  const handleUpdateContent = () => {
+    if (textRef.current) onUpdateContent(textRef.current.value);
+  };
 
   return (
     <>
@@ -32,17 +37,13 @@ const ContentModify = ({ content }: ContentModifyProps) => {
         </Modal>
       )}
       <InputField placeholder={'텍스트를 입력해주세요'} defaultValue={content} ref={textRef} />
-      <ContentButton right='25rem' backgroundColor='#ff0044'>
+      <ContentButton right='25' backgroundColor='#ff0044'>
         삭제하기
       </ContentButton>
-      <ContentButton
-        right='15rem'
-        backgroundColor='grey'
-        onClick={() => setIsPreviewModalOpen(true)}
-      >
+      <ContentButton right='15' backgroundColor='grey' onClick={() => setIsPreviewModalOpen(true)}>
         미리보기
       </ContentButton>
-      <ContentButton right='5rem' backgroundColor='#0067a3'>
+      <ContentButton right='5' backgroundColor='#0067a3' onClick={handleUpdateContent}>
         수정완료
       </ContentButton>
     </>
@@ -75,6 +76,6 @@ const ContentButton = styled.button<ContentButtonProps>`
     cursor: pointer;
   }
 
-  right: ${(props) => props.right};
+  right: ${(props) => props.right + 'rem'};
   background-color: ${(props) => props.backgroundColor};
 `;

--- a/src/pages/contents/[channelLink]/[boardId].tsx
+++ b/src/pages/contents/[channelLink]/[boardId].tsx
@@ -22,6 +22,7 @@ const boardContents = () => {
   };
 
   useEffect(() => {
+    setIsModify(false);
     if (!channelLink || !boardId) {
       router.push('/');
       return;

--- a/src/pages/contents/[channelLink]/[boardId].tsx
+++ b/src/pages/contents/[channelLink]/[boardId].tsx
@@ -21,6 +21,11 @@ const boardContents = () => {
     setContents(res.data);
   };
 
+  const handleContentUpdate = (updatedContent: string) => {
+    setContents(updatedContent);
+    setIsModify(false);
+  };
+
   useEffect(() => {
     setIsModify(false);
     if (!channelLink || !boardId) {
@@ -35,7 +40,7 @@ const boardContents = () => {
   return (
     <Container>
       {isModify ? (
-        <ContentModify content={contents} />
+        <ContentModify content={contents} onUpdateContent={handleContentUpdate} />
       ) : (
         <>
           <div

--- a/src/pages/contents/[channelLink]/[boardId].tsx
+++ b/src/pages/contents/[channelLink]/[boardId].tsx
@@ -1,4 +1,5 @@
 import authAPI from '@apis/authAPI';
+import ContentModify from '@components/Content/ContentModify';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useRouter } from 'next/router';
@@ -7,6 +8,7 @@ import { ReactMarkdown } from 'react-markdown/lib/react-markdown';
 
 const boardContents = () => {
   const [contents, setContents] = useState('');
+  const [isModify, setIsModify] = useState(false);
 
   const router = useRouter();
   const { channelLink, boardId } = router.query;
@@ -31,14 +33,21 @@ const boardContents = () => {
 
   return (
     <Container>
-      <div
-        css={css`
-          padding-bottom: 1rem;
-        `}
-      >
-        <ReactMarkdown children={contents} />
-      </div>
-      <ModifyButton>내용 수정</ModifyButton>
+      {isModify ? (
+        <ContentModify content={contents} />
+      ) : (
+        <>
+          <div
+            css={css`
+              padding-bottom: 1rem;
+            `}
+          >
+            <ReactMarkdown children={contents} />
+          </div>
+          <ModifyButton>공지 삭제</ModifyButton>
+          <ModifyButton onClick={() => setIsModify(true)}>내용 수정</ModifyButton>
+        </>
+      )}
     </Container>
   );
 };


### PR DESCRIPTION
## 🤠 개요

- closes: #62 
- 게시글을 수정할 수 있는 텍스트를 추가했어요!
- 현재 삭제하기랑 수정완료 버튼은 사용이 안되고 미리보기만 모달창으로 볼 수 있어요!
<!--
- 이슈번호
- 한줄 설명
- closes: #(이슈번호 입력해주세요)
  -->

## 💫 설명
## 문제점들
일단 현재 에러가 조금 많을 수 있어요
### 모달 문제
- 현재 <Modal> 컴포넌트의 기본 크기 및 무한정 늘어나는 사이즈의 문제가 있어요. 그래서 미리보기를 눌렀을떄 모달창이 이상하게 나올수가 있어요

### 텍스트에서 입력한 엔터가 markdown 에서 적용되지 않는문제
react-markdown 이 엔터를 못읽어서 엔터가 적용되지 않는데 react-markdown 의 추가 플러그인을 설치해서 해결되는지 확인해볼게요

### 수정 완료 클릭 후 행동
수정 완료를 클릭했을 때 어떻게 바뀐 텍스트를 바로 보여줄 수 있을까 고민중이에요..
만약 수정 완료를 클릭했을 때 바뀐 텍스트를 서버에 전송하고,
그 다음 페이지 이동하여 채널 게시판에 해당하는 텍스트를 받기위해 서버에 요청하면 리소스 소요가 크지 않을까 싶어 고민중이에요..
만약 좋은 방법 있으면 추천 부탁드려요!

### 테스트 문제
/pages/contents/[channelLink]/[boardId].tsx 파일을 import 해서 테스트 하려니까 JSX 가 아니라는 에러가 발생하네요..
일단 기능적인 컴포넌트는 없기에 이번 테스트는 넘길게요!
<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
![image](https://github.com/TheUpperPart/leaguehub-frontend/assets/71641127/c0455020-a8ce-4e4f-bef6-b66927e865e9)
![image](https://github.com/TheUpperPart/leaguehub-frontend/assets/71641127/e81d5bec-1f50-476c-b5e0-37b87e6e5c42)
