### PR TITLE
Fix/#70 오타 및 페이지 강제 이동

### DIFF
--- a/src/components/Content/ContentModify.tsx
+++ b/src/components/Content/ContentModify.tsx
@@ -80,7 +80,6 @@ const ContentButton = styled.button<ContentButtonProps>`
   &: hover {
     cursor: pointer;
   }
-
   right: ${(props) => props.right + 'rem'};
   background-color: ${(props) => props.backgroundColor};
 `;

--- a/src/components/Sidebar/ChannelBar/ChannelBar.tsx
+++ b/src/components/Sidebar/ChannelBar/ChannelBar.tsx
@@ -8,15 +8,12 @@ import { ChannelCircleProps } from '@type/channelCircle';
 import { useState } from 'react';
 import SelectChannelType from '@components/Sidebar/ChannelBar/SelectChannelType';
 
-
 interface ChannelBarProps {
   channels: ChannelCircleProps[];
   updateSelectedChannel: (channelId: string) => void;
 }
 
-
 const ChannelBar = ({ channels, updateSelectedChannel }: ChannelBarProps) => {
-
   const [isModal, setIsModal] = useState<boolean>(false);
 
   const handleModal = () => {

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -9,6 +9,7 @@ import Header from '@components/Header/Header';
 import { SERVER_URL } from '@config/index';
 import GlobalStyle from 'src/styles/GlobalStyle';
 import { ChannelCircleProps } from '@type/channelCircle';
+import { useRouter } from 'next/router';
 
 const fetchData = async () => {
   const response = await axios.get(SERVER_URL + '/api/channels', {
@@ -21,6 +22,8 @@ const fetchData = async () => {
 };
 
 const Layout = ({ children }: PropsWithChildren) => {
+  const router = useRouter();
+
   const [selectedChannelId, setSelectedChannelId] = useState<string | null>(null);
 
   const { data, isSuccess } = useQuery<ChannelCircleProps[]>(['getChannels'], fetchData, {
@@ -34,7 +37,7 @@ const Layout = ({ children }: PropsWithChildren) => {
 
   useEffect(() => {
     // 새로고침시 첫 번째 채널 보여주도록 설정
-    if (isSuccess) {
+    if (isSuccess && router.asPath === '/') {
       setSelectedChannelId(data[0].channelLink);
     }
   }, [data]);

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -12,7 +12,6 @@ import ChannelProvider from '@components/providers/ChannelProvider';
 
 import MakeGameProvider from '@components/providers/MakeGameProvider';
 
-
 if (process.env.NODE_ENV === 'development') {
   initMockAPI();
 }
@@ -30,7 +29,7 @@ export default function MyApp({ Component, pageProps }: AppProps) {
               <Layout>
                 <Component {...pageProps} />
               </Layout>
-             </MakeGameProvider>
+            </MakeGameProvider>
           </ChannelProvider>
         </ProfileProvider>
       </Hydrate>

--- a/src/pages/contents/[channelLink]/[boardId].tsx
+++ b/src/pages/contents/[channelLink]/[boardId].tsx
@@ -80,7 +80,7 @@ const ModifyButton = styled.button`
   padding: 1rem;
   border-radius: 1rem;
 
-  &: hover {
+  &:hover {
     cursor: pointer;
   }
 `;


### PR DESCRIPTION
## 🤠 개요

- closes: #70 
- src/pages/contents/[channelLink]/[boardId].tsx에서 &:와 hover 사이 오타로 CI가 안되는 문제 수정
- 루트 페이지에서만 첫 번째 채널의 첫 번째 보드로 강제 이동하도록 수정

## 💫 설명
-  src/pages/contents/[channelLink]/[boardId].tsx에서 &:와 hover 사이 오타로 CI가 안되는 문제를 수정했어요.
- 현재 선택된 채널을 layout에서 관리를 하는데 이로 인해 어떠한 페이지에서도 첫 번째 페이지의 첫 번째 보드로 페이지를 이동하는 문제가 있었어요.
- 그래서 layout에서 루트 페이지일 때만 첫 번째 채널의 첫 번째 보드로 강제 이동하도록 수정했어요.
- 더 좋은 방법이 있으면 알려주세요!


## 📷 스크린샷 (Optional)
- 고치기 전(mypage에서도 첫 번째 채널의 첫 번째 보드로 강제이동)
![녹화_2023_08_10_13_36_37_459](https://github.com/TheUpperPart/leaguehub-frontend/assets/100738049/f5426820-8e91-4c20-a26c-9b05600cd7dd)

- 고친 후
![녹화_2023_08_10_13_37_38_998](https://github.com/TheUpperPart/leaguehub-frontend/assets/100738049/e180ad95-982f-4e86-a5d9-2bf4cc5d1a3b)

