### PR TITLE
Feat/#72 jwt토큰 저장소 변경

### DIFF
--- a/src/apis/authAPI.ts
+++ b/src/apis/authAPI.ts
@@ -1,5 +1,6 @@
 import { SERVER_URL } from '@config/index';
 import axios from 'axios';
+import Cookies from 'js-cookie';
 
 const authAPI = axios.create({
   baseURL: SERVER_URL,
@@ -7,11 +8,11 @@ const authAPI = axios.create({
 
 // api 요청하기 전 수행
 authAPI.interceptors.request.use((config) => {
-  const accessToken = localStorage.getItem('accessToken');
+  const accessToken = Cookies.get('accessToken');
 
   // 액세스 토큰이 존재할 때만 탑재
   if (accessToken) {
-    config.headers['Authorization'] = `Bearer ${localStorage.getItem('accessToken')}`;
+    config.headers['Authorization'] = `Bearer ${accessToken}`;
   }
 
   return config;

--- a/src/components/providers/ProfileProvider.tsx
+++ b/src/components/providers/ProfileProvider.tsx
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import ProfileContext from '@contexts/ProfileContext';
 import { Profile } from '@type/profile';
 import authAPI from '@apis/authAPI';
+import Cookies from 'js-cookie';
 
 interface ProfileProviderProps {
   children: React.ReactNode;
@@ -19,8 +20,8 @@ const fetchProfile = async () => {
 
 const ProfileProvider = ({ children }: ProfileProviderProps) => {
   // 유저가 로그인 되어있는지 확인
-  const isHaveAccessToken =
-    typeof window !== 'undefined' ? localStorage.getItem('accessToken') : null; // 액세스 토큰 있는지 확인
+
+  const isHaveAccessToken = Cookies.get('accessToken');
 
   const [profile, setProfile] = useState<Profile | null>(null);
 

--- a/src/pages/auth.tsx
+++ b/src/pages/auth.tsx
@@ -5,6 +5,7 @@ import { useEffect } from 'react';
 
 import { Login } from '@type/login';
 import { SERVER_URL } from '@config/index';
+import Cookies from 'js-cookie';
 
 interface Props {
   data: Login;
@@ -16,8 +17,8 @@ const Auth = (props: Props) => {
   useEffect(() => {
     // 로그인 성공했을 때
     if (props.data.success) {
-      localStorage.setItem('accessToken', props.data.accessToken);
-      localStorage.setItem('refreshToken', props.data.refreshToken);
+      Cookies.set('accessToken', props.data.accessToken);
+      Cookies.set('refreshToken', props.data.refreshToken);
     }
 
     // 마지막에 방문한 path를 가져옴
@@ -37,8 +38,8 @@ export default Auth;
 export const getServerSideProps: GetServerSideProps<{ data: Login }> = async (context) => {
   try {
     const res = await axios<Omit<Login, 'success'>>({
-      method: 'get',
-      url: SERVER_URL + '/app/login/kakao',
+      method: 'post',
+      url: SERVER_URL + '/api/app/login/kakao',
       headers: {
         'Kakao-Code': `${context.query.code}`,
       },


### PR DESCRIPTION
## 🤠 개요

- closes: #72 
- 기존에 localStorage에 저장하던 jwt 토큰을 쿠키에 저장하도록 변경했어요.
- 또 api 요청할 때 cookie에서 accessToken을 꺼내서 헤더에 탑재하도록 변경했어요,


## 💫 설명
- localStorage에 jwt 토큰을 저장하면 SSR에서 사용할 수 없는 문제가 있어서 jwt 토큰을 쿠키에 저장하도록 변경했어요.
- 이로 인해, axios 인스턴스의 로직과 ProfileProvider 로직이 변경되었어요.

## 📷 스크린샷 (Optional)
