### PR TITLE
Feat/#73: 콘텐츠 보는 화면 상단에 채널게시판 제목도 추가

### DIFF
--- a/__mocks__/handlers/boardHandlers.ts
+++ b/__mocks__/handlers/boardHandlers.ts
@@ -109,6 +109,7 @@ const boardHandlers = [
 
   rest.get(SERVER_URL + '/api/channel/:channelLink/:boardId', (req, res, ctx) => {
     const { channelLink, boardId } = req.params;
+    const title = '임시제목';
     const content = `# H1
 ## H2
 ### H3
@@ -116,7 +117,7 @@ const boardHandlers = [
 ##### H5
 , React Markdown!\nThis is **${channelLink} ${boardId}** text rendered in a React component`;
 
-    return res(ctx.json(content));
+    return res(ctx.json({ title, content }));
   }),
 ];
 

--- a/src/components/Content/ContentModify.tsx
+++ b/src/components/Content/ContentModify.tsx
@@ -46,6 +46,7 @@ const ContentModify = ({ title, content, onUpdateContent }: ContentModifyProps) 
               text-align: start;
             `}
           >
+            <PreviewTitle>{titleRef.current.value}</PreviewTitle>
             <ReactMarkdown children={textRef.current.value} />
           </div>
         </Modal>
@@ -102,4 +103,13 @@ const ContentButton = styled.button<ContentButtonProps>`
   }
   right: ${(props) => props.right + 'rem'};
   background-color: ${(props) => props.backgroundColor};
+`;
+
+const PreviewTitle = styled.div`
+  font-size: 2em;
+  font-weight: 900;
+  padding-bottom: 2rem;
+  margin-bottom: 2rem;
+  border-bottom: 1px solid #c0c0c0;
+  text-align: center;
 `;

--- a/src/components/Content/ContentModify.tsx
+++ b/src/components/Content/ContentModify.tsx
@@ -23,17 +23,22 @@ const ContentModify = ({ title, content, onUpdateContent }: ContentModifyProps) 
   const textRef = useRef<HTMLTextAreaElement>(null);
 
   const handleUpdateContent = () => {
-    if (textRef.current === null || titleRef.current === null) alert('글자를 입력해주세요!');
-    else if (textRef.current.value.length < 5) alert('5글자 이상 입력해주세요!');
-    else {
-      const res = window.confirm('수정하겠습니까?');
-      if (res) {
-        const modifiedContent: Content = {
-          title: titleRef.current.value,
-          content: textRef.current.value,
-        };
-        onUpdateContent(modifiedContent);
-      }
+    if (textRef.current === null || titleRef.current === null) {
+      alert('글자를 입력해주세요!');
+      return;
+    }
+    if (textRef.current.value.length < 5) {
+      alert('5글자 이상 입력해주세요!');
+      return;
+    }
+
+    const res = window.confirm('수정하겠습니까?');
+    if (res) {
+      const modifiedContent: Content = {
+        title: titleRef.current.value,
+        content: textRef.current.value,
+      };
+      onUpdateContent(modifiedContent);
     }
   };
 

--- a/src/components/Content/ContentModify.tsx
+++ b/src/components/Content/ContentModify.tsx
@@ -1,12 +1,14 @@
 import Modal from '@components/Modal';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import { useEffect, useRef, useState } from 'react';
+import { Content } from '@pages/contents/[channelLink]/[boardId]';
+import { useRef, useState } from 'react';
 import { ReactMarkdown } from 'react-markdown/lib/react-markdown';
 
 interface ContentModifyProps {
+  title: string;
   content: string;
-  onUpdateContent: (updatedContent: string) => void;
+  onUpdateContent: (updatedContent: Content) => void;
 }
 
 interface ContentButtonProps {
@@ -15,22 +17,29 @@ interface ContentButtonProps {
   backgroundColor: string;
 }
 
-const ContentModify = ({ content, onUpdateContent }: ContentModifyProps) => {
+const ContentModify = ({ title, content, onUpdateContent }: ContentModifyProps) => {
   const [isPreviewModalOpen, setIsPreviewModalOpen] = useState(false);
+  const titleRef = useRef<HTMLInputElement>(null);
   const textRef = useRef<HTMLTextAreaElement>(null);
 
   const handleUpdateContent = () => {
-    if (textRef.current === null) alert('글자를 입력해주세요!');
+    if (textRef.current === null || titleRef.current === null) alert('글자를 입력해주세요!');
     else if (textRef.current.value.length < 5) alert('5글자 이상 입력해주세요!');
     else {
       const res = window.confirm('수정하겠습니까?');
-      if (res) onUpdateContent(textRef.current.value);
+      if (res) {
+        const modifiedContent: Content = {
+          title: titleRef.current.value,
+          content: textRef.current.value,
+        };
+        onUpdateContent(modifiedContent);
+      }
     }
   };
 
   return (
     <>
-      {isPreviewModalOpen && textRef.current && (
+      {isPreviewModalOpen && titleRef.current && textRef.current && (
         <Modal onClose={() => setIsPreviewModalOpen(false)}>
           <div
             css={css`
@@ -41,6 +50,7 @@ const ContentModify = ({ content, onUpdateContent }: ContentModifyProps) => {
           </div>
         </Modal>
       )}
+      <TitleField placeholder={'제목을 입력해주세요'} defaultValue={title} ref={titleRef} />
       <InputField placeholder={'텍스트를 입력해주세요'} defaultValue={content} ref={textRef} />
       <ContentButton right='25' backgroundColor='#ff0044'>
         삭제하기
@@ -57,10 +67,20 @@ const ContentModify = ({ content, onUpdateContent }: ContentModifyProps) => {
 
 export default ContentModify;
 
+const TitleField = styled.input`
+  width: 100%;
+  font-size: 1.5rem;
+  height: 5vh;
+  border: 2px solid #d3d3d3;
+  outline-color: #039be5;
+  border-radius: 1rem;
+  padding-left: 1rem;
+  margin-bottom: 2vh;
+`;
+
 const InputField = styled.textarea`
   width: 100%;
-  min-height: 75vh;
-  border: none;
+  min-height: 68vh;
   resize: vertical;
   border: 2px solid #d3d3d3;
   outline-color: #039be5;

--- a/src/pages/contents/[channelLink]/[boardId].tsx
+++ b/src/pages/contents/[channelLink]/[boardId].tsx
@@ -6,22 +6,31 @@ import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { ReactMarkdown } from 'react-markdown/lib/react-markdown';
 
+export interface Content {
+  title: string;
+  content: string;
+}
+
 const boardContents = () => {
-  const [contents, setContents] = useState('');
+  const [contents, setContents] = useState<Content>({ title: '', content: '' });
   const [isModify, setIsModify] = useState(false);
 
   const router = useRouter();
   const { channelLink, boardId } = router.query;
 
   const fetchBoardContent = async (channelLink: string, boardId: string) => {
-    const res = await authAPI<string>({
+    const res = await authAPI<Content>({
       method: 'get',
       url: `/api/channel/${channelLink}/${boardId}`,
     });
     setContents(res.data);
   };
 
-  const handleContentUpdate = (updatedContent: string) => {
+  const handleContentUpdate = ({ title, content }: Content) => {
+    const updatedContent: Content = {
+      title,
+      content,
+    };
     setContents(updatedContent);
     setIsModify(false);
   };
@@ -40,15 +49,21 @@ const boardContents = () => {
   return (
     <Container>
       {isModify ? (
-        <ContentModify content={contents} onUpdateContent={handleContentUpdate} />
+        <ContentModify
+          title={contents.title}
+          content={contents.content}
+          onUpdateContent={handleContentUpdate}
+        />
       ) : (
         <>
+          <Title>{contents.title}</Title>
           <div
             css={css`
+              padding-top: 2rem;
               padding-bottom: 1rem;
             `}
           >
-            <ReactMarkdown children={contents} />
+            <ReactMarkdown children={contents.content} />
           </div>
           <ModifyButton>공지 삭제</ModifyButton>
           <ModifyButton onClick={() => setIsModify(true)}>내용 수정</ModifyButton>
@@ -67,6 +82,13 @@ const Container = styled.div`
   max-height: 85vh;
   overflow: auto;
   padding-bottom: 5rem;
+`;
+
+const Title = styled.div`
+  font-size: 2em;
+  font-weight: 900;
+  padding-bottom: 2rem;
+  border-bottom: 1px solid #d3d3d3;
 `;
 
 const ModifyButton = styled.button`

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -32,15 +32,18 @@ const globalCss = css`
     list-style: none;
   }
   h1 {
-    font-size: 3em;
+    font-size: 2.5em;
   }
   h2 {
-    font-size: 2.5em;
+    font-size: 2.2em;
   }
   h3 {
     font-size: 2em;
   }
   h4 {
-    font-size: 1.5em;
+    font-size: 1.6em;
+  }
+  h5 {
+    font-size: 1.3em;
   }
 `;


### PR DESCRIPTION
## 🤠 개요

- closes: #73
- 콘텐츠 보는 화면 상단에 채널게시판 제목도 추가했어요 (콘텐츠 수정화면에서도 제목 보이도록 했어요)
- MSW 에서 채널, 게시판 ID 값에따라 제목, 콘텐츠를 응답하는데 제목은 모두 '임시제목' 으로 반환하도록 설정했어요 (편의상..)
<!--
- 이슈번호
- 한줄 설명
- closes: #(이슈번호 입력해주세요)
  -->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
<img width="1714" alt="image" src="https://github.com/TheUpperPart/leaguehub-frontend/assets/71641127/aac33f51-b7b1-4557-bad5-cbaae81b07f9">
<img width="1710" alt="image" src="https://github.com/TheUpperPart/leaguehub-frontend/assets/71641127/21a538f5-9b34-4393-a7c3-c4345eed8d7c">
<img width="1704" alt="image" src="https://github.com/TheUpperPart/leaguehub-frontend/assets/71641127/3040b24d-5ae4-4bf7-8f6b-972dd803119b">
<img width="1703" alt="image" src="https://github.com/TheUpperPart/leaguehub-frontend/assets/71641127/d435e434-eff0-4c7a-9f20-2ebfbe7a85b9">
