### PR TITLE
Fix/#80: 예외 처리 및 모킹 데이터 추가

### DIFF
--- a/__mocks__/handlers/channelHandlers.ts
+++ b/__mocks__/handlers/channelHandlers.ts
@@ -2,32 +2,46 @@ import { rest } from 'msw';
 import { SERVER_URL } from '@config/index';
 import { ChannelCircleProps } from '@type/channelCircle';
 
-const getChannels: ChannelCircleProps[] = [
-  {
-    channelLink: '123',
-    title: '부경대 총장기',
-    category: 'TFT',
-  },
-  {
-    channelLink: '234',
-    title: '부경대 총장기',
-    category: 'LOL',
-  },
-  {
-    channelLink: '345',
-    title: '부경대 총장기',
-    category: 'HS',
-  },
-  {
-    channelLink: '456',
-    title: '부경대 총장기',
-    category: 'FIFA',
-  },
+const getChannels: ChannelCircleProps[][] = [
+  [
+    {
+      channelLink: '123',
+      title: '부경대 총장기',
+      category: 0,
+      customChannelIndex: 0,
+    },
+    {
+      channelLink: '234',
+      title: '부경대 총장기',
+      category: 1,
+      customChannelIndex: 1,
+    },
+    {
+      channelLink: '345',
+      title: '부경대 총장기',
+      category: 2,
+      customChannelIndex: 2,
+    },
+    {
+      channelLink: '456',
+      title: '부경대 총장기',
+      category: 3,
+      customChannelIndex: 3,
+    },
+  ],
+  [],
 ];
 
 const channelHandlers = [
   rest.get(SERVER_URL + '/api/channels', (req, res, ctx) => {
-    return res(ctx.json(getChannels));
+    const bearer = req.headers.get('Authorization') || 'no-token';
+    const [bearerStr, tokenValue] = bearer?.split(' ');
+
+    if (tokenValue === '123') {
+      return res(ctx.json(getChannels[1]));
+    }
+
+    return res(ctx.json(getChannels[0]));
   }),
 ];
 

--- a/__test__/components/Sidebar/ChannelCircle/ChannelCircle.test.tsx
+++ b/__test__/components/Sidebar/ChannelCircle/ChannelCircle.test.tsx
@@ -1,11 +1,13 @@
 import { render, screen } from '@testing-library/react';
 import ChannelCircle from '@components/Sidebar/ChannelCircle/ChannelCircle';
+import { ChannelCircleProps } from '@type/channelCircle';
 
 describe('채널 테스트', () => {
-  const initalState = {
+  const initalState: ChannelCircleProps = {
     channelLink: 'ab5gx',
     title: '부경대 총장기',
-    category: 'TFT',
+    category: 0,
+    customChannelIndex: 0,
   };
 
   it('채널 이름을 가진 컴포넌트가 있다.', () => {
@@ -17,8 +19,9 @@ describe('채널 테스트', () => {
   const initalState2 = {
     channelLink: 'ab5gx',
     title: '부경대 총장기',
-    category: 'TFT',
+    category: 0,
     imgSrc: '1.jpeg',
+    customChannelIndex: 1,
   };
 
   it('백그라운드 사진이 있다.', () => {

--- a/src/@types/channelCircle.ts
+++ b/src/@types/channelCircle.ts
@@ -1,6 +1,7 @@
 export interface ChannelCircleProps {
   channelLink: string;
   title: string;
-  category: string;
+  category: number;
   imgSrc?: string;
+  customChannelIndex: number;
 }

--- a/src/components/Sidebar/ChannelBar/ChannelBar.tsx
+++ b/src/components/Sidebar/ChannelBar/ChannelBar.tsx
@@ -23,7 +23,7 @@ const ChannelBar = ({ channels, updateSelectedChannel }: ChannelBarProps) => {
   return (
     <ChannelbarContainer>
       {channels &&
-        channels.map(({ channelLink, title, category }) => (
+        channels.map(({ channelLink, title, category, customChannelIndex }) => (
           <div
             key={channelLink}
             onClick={() => updateSelectedChannel(channelLink)}
@@ -32,7 +32,12 @@ const ChannelBar = ({ channels, updateSelectedChannel }: ChannelBarProps) => {
               margin-bottom: 2.2rem;
             `}
           >
-            <ChannelCircle channelLink={channelLink} title={title} category={category} />
+            <ChannelCircle
+              channelLink={channelLink}
+              title={title}
+              category={category}
+              customChannelIndex={customChannelIndex}
+            />
           </div>
         ))}
       <ChannelParticipate onClick={() => setIsModal(true)}>

--- a/src/components/Sidebar/ChannelCircle/ChannelCircle.tsx
+++ b/src/components/Sidebar/ChannelCircle/ChannelCircle.tsx
@@ -1,13 +1,20 @@
+import { GameEnum } from '@constants/MakeGame';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
 import { ChannelCircleProps } from 'src/@types/channelCircle';
 
-const ChannelCircle = ({ channelLink, title, category, imgSrc }: ChannelCircleProps) => {
+const ChannelCircle = ({
+  channelLink,
+  title,
+  category,
+  imgSrc,
+  customChannelIndex,
+}: ChannelCircleProps) => {
   return (
     <ChannelBtn key={channelLink} url={imgSrc}>
       <ChannelName>{title}</ChannelName>
-      <ChannelGame>{category}</ChannelGame>
+      <ChannelGame>{GameEnum[category]}</ChannelGame>
     </ChannelBtn>
   );
 };

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -10,12 +10,12 @@ import { SERVER_URL } from '@config/index';
 import GlobalStyle from 'src/styles/GlobalStyle';
 import { ChannelCircleProps } from '@type/channelCircle';
 import { useRouter } from 'next/router';
+import authAPI from '@apis/authAPI';
 
 const fetchData = async () => {
-  const response = await axios.get(SERVER_URL + '/api/channels', {
-    headers: {
-      Authorization: 'User Token',
-    },
+  const response = await authAPI<ChannelCircleProps[]>({
+    method: 'get',
+    url: SERVER_URL + '/api/channels',
   });
 
   return response.data;
@@ -26,10 +26,7 @@ const Layout = ({ children }: PropsWithChildren) => {
 
   const [selectedChannelId, setSelectedChannelId] = useState<string | null>(null);
 
-  const { data, isSuccess } = useQuery<ChannelCircleProps[]>(['getChannels'], fetchData, {
-    staleTime: Infinity,
-    cacheTime: Infinity,
-  });
+  const { data, isSuccess } = useQuery<ChannelCircleProps[]>(['getChannels'], fetchData);
 
   const updateSelectedChannel = (channelId: string) => {
     setSelectedChannelId(channelId);
@@ -38,7 +35,7 @@ const Layout = ({ children }: PropsWithChildren) => {
   useEffect(() => {
     // 새로고침시 첫 번째 채널 보여주도록 설정
     if (isSuccess && router.asPath === '/') {
-      setSelectedChannelId(data[0].channelLink);
+      data.length !== 0 && setSelectedChannelId(data[0].channelLink);
     }
   }, [data]);
 


### PR DESCRIPTION
## 🤠 개요

- closes: #80 
- get /api/channels api의 추가된 데이터의 속성을 ChannelCircleProps에 추가
- 참가된 채널이 없을 때 예외처리
- enum사용

## 💫 설명
- 기존의 로직으로는 채널 목록을 가져온 후 첫 번째 채널의 첫 번째 보드의 url로 강제 이동했어요. 하지만 참가한 채널이 없을 때를 고려하지 않아 해당 부분에서 에러가 발생했어요. 따라서 참가한 채널이 있을 때만 이동하게 만들었어요.
- get /api/channels api에서 customChannelIndex 속성이 추가되고 category의 타입이 number로 변경돼서 해당 부분을 적용했어요.
  - number로 변경됨에 따라 GameEnum를 사용하여 게임을 표시했어요.
  - 추가된 속성과 변경 된 타입을 컴포넌트에 적용했어요.
- 빈 배열(참가된 채널이 없는) 모킹 데이터를 추가했어요.
  - accessToken이 123일 때 빈 배열을 반환해요.

## 📷 스크린샷 (Optional)
- 참가된 채널이 있을 떄
첫 번째 채널의 첫 번째 보드로 이동해요.
![녹화_2023_08_12_23_51_55_680](https://github.com/TheUpperPart/leaguehub-frontend/assets/100738049/4eb3d838-9fc6-4c6b-ae05-2fa74e0da4e8)

- 참가된 채널이 없을 때
소개 페이지(루트 페이지)에 있어요.
![녹화_2023_08_12_23_52_34_958](https://github.com/TheUpperPart/leaguehub-frontend/assets/100738049/39e7f9ad-0a6a-4857-bfe1-6cfb4c793b37)
