### PR TITLE
Config: 이미지 도메인 등록

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  images: {
+    domains: ['localhost', 'k.kakaocdn.net', 's3.ap-northeast-2.amazonaws.com'],
+  },
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;


### PR DESCRIPTION
## 🤠 개요

- closes: #83 
- next/Image에서 사용할 이미지 도메인을 미리 등록했어요.

## 💫 설명
- next/Image에서 이미지 src로 사용할 도메인을 미리 next.config.js에 등록을 해야해요.
- 따라서, localhost, 카카오 이미지, 아마존 s3를 미리 등록했어요. 상황에 따라 도메인이 추가되거나 삭제될 수 있어요.


## 📷 스크린샷 (Optional)
