### PR TITLE
Design/#85: 사이드바 가로크기 고정 및 스크롤 바 삭제

### DIFF
--- a/src/components/Sidebar/BoardBar/BoardBar.tsx
+++ b/src/components/Sidebar/BoardBar/BoardBar.tsx
@@ -80,7 +80,7 @@ const BoardBar = ({ channelId }: { channelId: string }) => {
 };
 
 const Container = styled.div`
-  width: 24rem;
+  width: 20rem;
   height: 100vh;
   background-color: #202b37;
   overflow: auto;

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -46,8 +46,12 @@ const Layout = ({ children }: PropsWithChildren) => {
     <>
       <GlobalStyle />
       <CommonLayout>
-        {data && <ChannelBar channels={data} updateSelectedChannel={updateSelectedChannel} />}
-        {selectedChannelId && <BoardBar channelId={selectedChannelId} />}
+        <SidebarWrapper>
+          {data && <ChannelBar channels={data} updateSelectedChannel={updateSelectedChannel} />}
+        </SidebarWrapper>
+        <SidebarWrapper>
+          {selectedChannelId && <BoardBar channelId={selectedChannelId} />}
+        </SidebarWrapper>
         <Wrapper>
           <Header />
           <main>{children}</main>
@@ -63,6 +67,10 @@ const CommonLayout = styled.div`
 
 const Wrapper = styled.div`
   width: 100%;
+`;
+
+const SidebarWrapper = styled.div`
+  flex: 0 0;
 `;
 
 export default Layout;

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -46,4 +46,12 @@ const globalCss = css`
   h5 {
     font-size: 1.3em;
   }
+  ::-webkit-scrollbar {
+    width: 0;
+    background-color: transparent;
+  }
+  ::-webkit-scrollbar-thumb {
+    background-color: rgba(0, 0, 0, 0);
+  }
+  scrollbar-width: none;
 `;


### PR DESCRIPTION
## 🤠 개요

- closes: #85 
- 창 줄여도 사이드바의 가로 크기는 고정되도록 수정했어요
- 스크롤 바는 안보이도록 수정했어요
<!--
- 이슈번호
- 한줄 설명
- closes: #(이슈번호 입력해주세요)
  -->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
<img width="1027" alt="image" src="https://github.com/TheUpperPart/leaguehub-frontend/assets/71641127/374c9002-456d-4818-9e35-de1821709656">
