### PR TITLE
Refactor/#95 대회 개최 페이지 리팩토링

### DIFF
--- a/__mocks__/handlers/channelHandlers.ts
+++ b/__mocks__/handlers/channelHandlers.ts
@@ -32,6 +32,15 @@ const getChannels: ChannelCircleProps[][] = [
   [],
 ];
 
+const postChannels: ChannelCircleProps[] = [
+  {
+    channelLink: '26734',
+    title: '부경대 추가대회',
+    category: 1,
+    customChannelIndex: 4,
+  },
+];
+
 const channelHandlers = [
   rest.get(SERVER_URL + '/api/channels', (req, res, ctx) => {
     const bearer = req.headers.get('Authorization') || 'no-token';
@@ -42,6 +51,10 @@ const channelHandlers = [
     }
 
     return res(ctx.json(getChannels[0]));
+  }),
+
+  rest.post(SERVER_URL + '/api/channel', (req, res, ctx) => {
+    return res(ctx.json(postChannels[0]));
   }),
 ];
 

--- a/src/components/Button/Toggle/index.tsx
+++ b/src/components/Button/Toggle/index.tsx
@@ -30,8 +30,8 @@ const Button = styled.button<Circle>`
   margin: 0;
   padding: 0;
   border: none;
-  width: 10rem;
-  height: 5rem;
+  width: 8rem;
+  height: 3rem;
 
   transition: all 0.3s ease-in-out;
 
@@ -43,10 +43,10 @@ const Button = styled.button<Circle>`
 
 const Circle = styled.div<Circle>`
   position: absolute;
-  width: 3rem;
-  height: 3rem;
-  top: 1rem;
-  left: ${(prop) => (prop.isOn ? '6rem' : '1rem')};
+  width: 2rem;
+  height: 2rem;
+  top: 0.5rem;
+  left: ${(prop) => (prop.isOn ? '5rem' : '1rem')};
 
   transition: all 0.3s ease-in-out;
 

--- a/src/components/MakeChannel/CustomRule.tsx
+++ b/src/components/MakeChannel/CustomRule.tsx
@@ -17,18 +17,13 @@ const CustomRule = ({ state }: Props) => {
     const tierToNum = Number(e.target.value);
 
     setTier(tierToNum);
-    if (tierToNum === 2400) {
+    if (tierToNum >= 2400) {
       setGrade(0);
     }
   };
 
-  const handleGrade = (e: ChangeEvent<HTMLSelectElement | HTMLInputElement>) => {
-    if (isNaN(Number(e.target.value))) {
-      return alert('숫자만 입력하세요!');
-    }
-
+  const handleGrade = (e: ChangeEvent<HTMLSelectElement>) => {
     const gradeToNum = Number(e.target.value);
-
     setGrade(gradeToNum);
   };
 
@@ -38,10 +33,7 @@ const CustomRule = ({ state }: Props) => {
 
   return (
     <Container>
-      <select onChange={handleTier} defaultValue={'none'}>
-        <option disabled value='none'>
-          티어 선택
-        </option>
+      <select onChange={handleTier} defaultValue={'0'}>
         {Object.keys(TFTTier).map((tier) => {
           return (
             <option key={tier} value={TFTTier[tier].defaultValue}>
@@ -51,9 +43,7 @@ const CustomRule = ({ state }: Props) => {
         })}
       </select>
 
-      {tier === 2400 ? (
-        <input placeholder='점수 입력 ex) 100점 이상' value={grade} onChange={handleGrade}></input>
-      ) : (
+      {tier < 2400 && (
         <select onChange={handleGrade}>
           <option value='0'>4 티어</option>
           <option value='100'>3 티어</option>

--- a/src/components/MakeChannel/SelectGame.tsx
+++ b/src/components/MakeChannel/SelectGame.tsx
@@ -4,17 +4,17 @@ import styled from '@emotion/styled';
 import useMakeGame from '@hooks/useMakeGame';
 
 const SelectGame = () => {
-  const { handleSelectCategory } = useMakeGame();
+  const { handleSelectGameCategory } = useMakeGame();
 
   return (
     <Container>
       <Wrapper>
         <Title>개최하실 게임을 선택해주세요.</Title>
         <GameContainer>
-          <GameBtn onClick={() => handleSelectCategory(GameEnum.TFT)}>TFT</GameBtn>
-          <GameBtn onClick={() => handleSelectCategory(GameEnum.LOL)}>L.O.L</GameBtn>
-          <GameBtn onClick={() => handleSelectCategory(GameEnum.HSS)}>하스스톤</GameBtn>
-          <GameBtn onClick={() => handleSelectCategory(GameEnum.FIFA)}>FIFA</GameBtn>
+          <GameBtn onClick={() => handleSelectGameCategory(GameEnum.TFT)}>TFT</GameBtn>
+          <GameBtn onClick={() => handleSelectGameCategory(GameEnum.LOL)}>L.O.L</GameBtn>
+          <GameBtn onClick={() => handleSelectGameCategory(GameEnum.HSS)}>하스스톤</GameBtn>
+          <GameBtn onClick={() => handleSelectGameCategory(GameEnum.FIFA)}>FIFA</GameBtn>
         </GameContainer>
       </Wrapper>
     </Container>

--- a/src/components/MakeChannel/SelectRule.tsx
+++ b/src/components/MakeChannel/SelectRule.tsx
@@ -44,19 +44,19 @@ const SelectRule = () => {
               value={basicInfo.title}
               onChange={(e) => handleBasicInfo('title', e)}
             />
-
             <RuleInput
               placeholder='참여자 수 ex) 32'
               type='number'
               value={basicInfo.participationNum === 0 ? '' : basicInfo.participationNum}
               onChange={(e) => handleBasicInfo('participationNum', e)}
             />
+            <RuleInfo>*입력한 참여자 수의 75%가 참여해야 대회를 시작할 수 있습니다.</RuleInfo>
           </InputContainer>
         </Rule>
         <Rule>
-          <RuleTitle>3. 커스텀 룰(선택 사항)</RuleTitle>
+          <RuleTitle>3. 커스텀 룰</RuleTitle>
           <CustomContainer>
-            <CustomTitle>최대 티어 제한 여부</CustomTitle>
+            <CustomTitle>최대 티어</CustomTitle>
             <ToggleButton
               isOn={isUseCustomRule.tierMax}
               changeState={() => handleIsUseCustomRule('tierMax')}
@@ -64,7 +64,7 @@ const SelectRule = () => {
             {isUseCustomRule.tierMax && <CustomRule state='tierMax' />}
           </CustomContainer>
           <CustomContainer>
-            <CustomTitle>최소 티어 제한 여부</CustomTitle>
+            <CustomTitle>최소 티어</CustomTitle>
             <ToggleButton
               isOn={isUseCustomRule.tierMin}
               changeState={() => handleIsUseCustomRule('tierMin')}
@@ -72,7 +72,7 @@ const SelectRule = () => {
             {isUseCustomRule.tierMin && <CustomRule state='tierMax' />}
           </CustomContainer>
           <CustomContainer>
-            <CustomTitle>최소 판수 제한 여부</CustomTitle>
+            <CustomTitle>최소 판수</CustomTitle>
             <ToggleButton
               isOn={isUseCustomRule.playCount}
               changeState={() => handleIsUseCustomRule('playCount')}
@@ -119,8 +119,10 @@ const RuleTitle = styled.h2`
 `;
 
 const CustomContainer = styled.div`
-  display: flex;
-  flex-direction: column;
+  height: 8rem;
+  display: grid;
+  align-items: center;
+  grid-template-columns: 10rem 10rem 1fr;
 `;
 
 const InputContainer = styled.div`
@@ -141,6 +143,10 @@ const RuleInput = styled.input`
   border-radius: 1rem;
   font-size: 2rem;
   padding: 1rem;
+`;
+
+const RuleInfo = styled.span`
+  font-size: 1.8rem;
 `;
 
 const RuleBtn = styled(Button)<{ isSelected: boolean }>`

--- a/src/components/providers/MakeGameProvider.tsx
+++ b/src/components/providers/MakeGameProvider.tsx
@@ -1,6 +1,7 @@
+import { ChangeEvent, useState } from 'react';
+
 import { TFTInitialValue } from '@constants/MakeGame';
 import MakeGameContext from '@contexts/MakeGameContext';
-import { ChangeEvent, useState } from 'react';
 
 interface MakeGameProps {
   children: React.ReactNode;
@@ -35,15 +36,10 @@ const MakeGameProvider = ({ children }: MakeGameProps) => {
   } = TFTInitialValue;
 
   const [currentStep, setCurrentStep] = useState<number>(initCurrentStep);
-
-  const [category, setCategory] = useState<number>(initCategory);
-
+  const [gameCategory, setGameCategory] = useState<number>(initCategory);
   const [matchFormat, setMatchFormat] = useState<number>(initMatchFormat);
-
   const [basicInfo, setBasicInfo] = useState<BasicInfo>(initBasicInfo);
-
   const [isUseCustomRule, setIsUseCustomRule] = useState<IsUseCustomRule>(initIsUseCustomRule);
-
   const [customRule, setCustomRule] = useState<CustomRule>(initCustomRule);
 
   const handleCurrentStep = () => {
@@ -52,8 +48,8 @@ const MakeGameProvider = ({ children }: MakeGameProps) => {
     }
   };
 
-  const handleSelectCategory = (category: number) => {
-    setCategory(category);
+  const handleSelectGameCategory = (category: number) => {
+    setGameCategory(category);
     handleCurrentStep();
   };
 
@@ -73,24 +69,35 @@ const MakeGameProvider = ({ children }: MakeGameProps) => {
     if (isNaN(Number(value))) {
       return alert('숫자만 입력하세요!');
     }
-
     setCustomRule({ ...customRule, [type]: value });
   };
 
   const resetState = () => {
     setCurrentStep(initCurrentStep);
-    setCategory(initCategory);
+    setGameCategory(initCategory);
     setMatchFormat(initMatchFormat);
     setBasicInfo(initBasicInfo);
     setIsUseCustomRule(initIsUseCustomRule);
     setCustomRule(initCustomRule);
   };
 
+  const isHaveBlankValue = () => {
+    if (
+      gameCategory < 0 ||
+      matchFormat < 0 ||
+      basicInfo.title.length === 0 ||
+      basicInfo.participationNum <= 0
+    ) {
+      return true;
+    }
+    return false;
+  };
+
   const contextValue = {
     currentStep,
     handleCurrentStep,
-    category,
-    handleSelectCategory,
+    gameCategory,
+    handleSelectGameCategory,
     basicInfo,
     handleBasicInfo,
     matchFormat,
@@ -100,6 +107,7 @@ const MakeGameProvider = ({ children }: MakeGameProps) => {
     customRule,
     handleCustomRule,
     resetState,
+    isHaveBlankValue,
   };
 
   return <MakeGameContext.Provider value={contextValue}>{children}</MakeGameContext.Provider>;

--- a/src/constants/MakeGame.ts
+++ b/src/constants/MakeGame.ts
@@ -24,7 +24,7 @@ interface TFTInitial {
 export const TFTInitialValue: TFTInitial = {
   initCurrentStep: 0,
   initCategory: -1,
-  initMatchFormat: -1,
+  initMatchFormat: 0,
   initBasicInfo: {
     title: '',
     participationNum: 0,

--- a/src/constants/TFT.ts
+++ b/src/constants/TFT.ts
@@ -31,7 +31,15 @@ export const TFTTier: TFTTiers = {
     defaultValue: 2000,
   },
   Master: {
-    displayName: '마스터 이상',
+    displayName: '마스터',
     defaultValue: 2400,
+  },
+  GrandMaster: {
+    displayName: '그랜드 마스터',
+    defaultValue: 2800,
+  },
+  Challenger: {
+    displayName: '챌린저',
+    defaultValue: 3200,
   },
 };

--- a/src/contexts/MakeGameContext.tsx
+++ b/src/contexts/MakeGameContext.tsx
@@ -4,8 +4,8 @@ import { ChangeEvent, createContext } from 'react';
 interface MakeGameState {
   currentStep: number;
   handleCurrentStep: () => void;
-  category: number;
-  handleSelectCategory: (category: number) => void;
+  gameCategory: number;
+  handleSelectGameCategory: (category: number) => void;
   basicInfo: BasicInfo;
   handleBasicInfo: (type: keyof BasicInfo, e: ChangeEvent<HTMLInputElement>) => void;
   matchFormat: number;
@@ -15,6 +15,7 @@ interface MakeGameState {
   customRule: CustomRule;
   handleCustomRule: (type: keyof CustomRule, value: number) => void;
   resetState: () => void;
+  isHaveBlankValue: () => boolean;
 }
 
 const MakeGameContext = createContext<MakeGameState | null>(null);


### PR DESCRIPTION
## 🤠 개요

- closes: #95 
- 토글 버튼의 크기를 수정했어요.
- 대회 개최중에 다른 페이지로 이동 후, 다시 대회 개최 버튼을 클릭했을 때 기존에 작성하던 정보를 불러올 수 있는 기능을 추가했어요.
- 대회 생성을 성공하면 대회목록에 대회를 추가해요.
## 💫 설명
- 기존의 토글 버튼의 크기가 너무 커서 조금 줄였어요.
- 또, 현재 대회를 개최중이다가 다른 대회 페이지로 이동했을 때 작성중인 정보를 저장해요. 추후에 다시 대회 개최를 눌렀을 때 기존에 작성중인 정보를 불러올건지 물어봐요.
  -  이 부분은, 대회 개최를 모달창으로 하게되면 아마 사라질 것 같아요. 
- 대회 정보를 빈 값없이 입력하면 api 요청을 하고 생성된 대회를 대회 목록에 추가해요.
- 현재 mock 데이터가 고정되어있어 입력한 대회 명이 아니라 고정적인 이름을 반환해요.
  - 추후에, mock 데이터를 수정할게요 

## 📷 스크린샷 (Optional)
- 기존에 작성중인 정보를 불러오고 대회를 개최하는 스크린샷이에요.
![녹화_2023_08_15_18_53_44_114](https://github.com/TheUpperPart/leaguehub-frontend/assets/100738049/aa704d1b-5dce-44ab-b2e3-f1783f87abf0)
