### PR TITLE
Fix: 최소티어 설정가능하도록 변경

### DIFF
--- a/src/components/MakeChannel/SelectRule.tsx
+++ b/src/components/MakeChannel/SelectRule.tsx
@@ -69,7 +69,7 @@ const SelectRule = () => {
               isOn={isUseCustomRule.tierMin}
               changeState={() => handleIsUseCustomRule('tierMin')}
             />
-            {isUseCustomRule.tierMin && <CustomRule state='tierMax' />}
+            {isUseCustomRule.tierMin && <CustomRule state='tierMin' />}
           </CustomContainer>
           <CustomContainer>
             <CustomTitle>최소 판수</CustomTitle>


### PR DESCRIPTION
## 🤠 개요

- closes: #108 
- 최소티어가 설정되지 않던 문제를 해결했어요.


## 💫 설명
tierMin을 CustomRule 컴포넌트에 props로 전달해야하는데 tierMax를 전달해서 최소 티어를 설정할 수 없던 문제를 해결했어요.

## 📷 스크린샷 (Optional)
