### PR TITLE
Feat/#111: 관리자가 대회 참여자를 강퇴할 수 있도록 추가

### DIFF
--- a/__mocks__/handlers/profileHandlers.ts
+++ b/__mocks__/handlers/profileHandlers.ts
@@ -17,7 +17,7 @@ const profileHandlers = [
       return res(ctx.status(401), ctx.json({ message: '허용되지 않은 사용자' }));
     }
   }),
-  rest.get(SERVER_URL + '/api/profile/player', (req, res, ctx) => {
+  rest.get(SERVER_URL + '/api/:channelLink/players', (req, res, ctx) => {
     const participants: Participant[] = [
       {
         pk: 0,
@@ -93,6 +93,9 @@ const profileHandlers = [
       },
     ];
     return res(ctx.status(200), ctx.json(participants));
+  }),
+  rest.post(SERVER_URL + '/api/:channelLink/:participantId/observer', (req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(''));
   }),
 ];
 

--- a/src/components/Modal/ParticipantLists/ParticipantUser.tsx
+++ b/src/components/Modal/ParticipantLists/ParticipantUser.tsx
@@ -1,6 +1,7 @@
 import authAPI from '@apis/authAPI';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
+import useChannels from '@hooks/useChannels';
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
 
@@ -14,6 +15,8 @@ export interface Participant {
 
 const ParticipantUser = () => {
   const [participants, setParticipants] = useState<Participant[]>();
+
+  const { channelPermission } = useChannels();
 
   const fetchData = async () => {
     const res = await authAPI<Participant[]>({ method: 'get', url: '/api/profile/player' });
@@ -42,14 +45,17 @@ const ParticipantUser = () => {
             <StyledImage src={participant.imgSrc} alt='참가자' width={50} height={50} />
             {participant.nickname}
           </div>
-          <div
-            css={css`
-              font-size: 1.1rem;
-              color: #adb5bd;
-            `}
-          >
-            {combineText(participant.gameId, participant.tier)}
-          </div>
+          <ParticipantInfo>
+            <div
+              css={css`
+                font-size: 1.1rem;
+                color: #adb5bd;
+              `}
+            >
+              {combineText(participant.gameId, participant.tier)}
+            </div>
+            {channelPermission === 0 && <KickUserButton>강퇴</KickUserButton>}
+          </ParticipantInfo>
         </ParticipantWrapper>
       ))}
     </ParticipantContainer>
@@ -75,7 +81,23 @@ const ParticipantWrapper = styled.li`
   }
 `;
 
+const ParticipantInfo = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+`;
+
 const StyledImage = styled(Image)`
   border-radius: 1rem;
   margin-right: 2rem;
+`;
+
+const KickUserButton = styled.button`
+  border: none;
+  background-color: #ff0044;
+  width: 3rem;
+  height: 3rem;
+  font-size: 1.5rem;
+  border-radius: 0.5rem;
+  margin-left: 1rem;
 `;

--- a/src/components/Sidebar/BoardBar/BoardBar.tsx
+++ b/src/components/Sidebar/BoardBar/BoardBar.tsx
@@ -21,9 +21,10 @@ const BoardBar = ({ channelLink }: { channelLink: string }) => {
     cacheTime: Infinity,
   });
 
-  const { setChannelPermission } = useChannels();
+  const { setCurrentChannel, setChannelPermission } = useChannels();
 
   useEffect(() => {
+    setCurrentChannel(channelLink);
     setChannelPermission(data?.permission);
   }, [data]);
 

--- a/src/components/providers/ChannelsProvider.tsx
+++ b/src/components/providers/ChannelsProvider.tsx
@@ -78,7 +78,7 @@ const ChannelsProvider = ({ children }: Props) => {
         setChannelPermission,
         addChannel,
         removeChannel,
-        dragAndDropChannels
+        dragAndDropChannels,
       }}
     >
       {children}

--- a/src/components/providers/ChannelsProvider.tsx
+++ b/src/components/providers/ChannelsProvider.tsx
@@ -22,6 +22,7 @@ const fetchChannels = async () => {
 const ChannelsProvider = ({ children }: Props) => {
   const isHaveAccessToken = Cookies.get('accessToken');
 
+  const [currentChannel, setCurrentChannel] = useState<string>('');
   const [channelPermission, setChannelPermission] = useState<number>();
   const [channels, setChannels] = useState<ChannelCircleProps[]>([]);
 
@@ -48,7 +49,15 @@ const ChannelsProvider = ({ children }: Props) => {
 
   return (
     <ChannelsContext.Provider
-      value={{ channels, channelPermission, setChannelPermission, addChannel, removeChannel }}
+      value={{
+        channels,
+        currentChannel,
+        setCurrentChannel,
+        channelPermission,
+        setChannelPermission,
+        addChannel,
+        removeChannel,
+      }}
     >
       {children}
     </ChannelsContext.Provider>

--- a/src/contexts/ChannelsContext.tsx
+++ b/src/contexts/ChannelsContext.tsx
@@ -4,6 +4,8 @@ import { ChannelCircleProps } from '@type/channelCircle';
 
 interface ChannelsContextProps {
   channels: ChannelCircleProps[] | [];
+  currentChannel: string | undefined;
+  setCurrentChannel: React.Dispatch<React.SetStateAction<string>>;
   channelPermission: number | undefined;
   setChannelPermission: React.Dispatch<React.SetStateAction<number | undefined>>;
   addChannel: (channel: ChannelCircleProps) => void;


### PR DESCRIPTION
## 🤠 개요

- closes: #111 
- 관리자만 참여자 강퇴할 수 있는 버튼이 보이고 강퇴를 시킬 수 있어요
<!--
- 이슈번호
- 한줄 설명
- closes: #(이슈번호 입력해주세요)
  -->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
<img width="614" alt="image" src="https://github.com/TheUpperPart/leaguehub-frontend/assets/71641127/271802fd-ff33-489c-aea2-714f3159b93a">
