### PR TITLE
Feat/#66 대진표 헤더 컴포넌트 만들기

### DIFF
--- a/__mocks__/browser.ts
+++ b/__mocks__/browser.ts
@@ -7,6 +7,7 @@ import profileHandlers from '@mocks/handlers/profileHandlers';
 import statHandlers from '@mocks/handlers/statHandlers';
 import makeGameHandlers from './handlers/makeGameHandlers';
 import mypageHandlers from './handlers/mypageHandlers';
+import bracketHandlers from './handlers/bracketHandlers';
 
 export const worker = setupWorker(
   ...testHandlers,
@@ -16,4 +17,5 @@ export const worker = setupWorker(
   ...statHandlers,
   ...makeGameHandlers,
   ...mypageHandlers,
+  ...bracketHandlers,
 );

--- a/__mocks__/handlers/bracketHandlers.ts
+++ b/__mocks__/handlers/bracketHandlers.ts
@@ -5,7 +5,7 @@ const bracketHandlers = [
   rest.get(SERVER_URL + '/api/match/:channelLink', (req, res, ctx) => {
     const { channelLink } = req.params;
 
-    return res(ctx.json({ roundList: [64, 32, 16, 8] }));
+    return res(ctx.json({ roundList: [1, 2, 3, 4], liveRound: 1 }));
   }),
 ];
 

--- a/__mocks__/handlers/bracketHandlers.ts
+++ b/__mocks__/handlers/bracketHandlers.ts
@@ -1,0 +1,12 @@
+import { SERVER_URL } from '@config/index';
+import { rest } from 'msw';
+
+const bracketHandlers = [
+  rest.get(SERVER_URL + '/api/match/:channelLink', (req, res, ctx) => {
+    const { channelLink } = req.params;
+
+    return res(ctx.json({ roundList: [64, 32, 16, 8] }));
+  }),
+];
+
+export default bracketHandlers;

--- a/__mocks__/server.ts
+++ b/__mocks__/server.ts
@@ -7,6 +7,7 @@ import profileHandlers from '@mocks/handlers/profileHandlers';
 import statHandlers from '@mocks/handlers/statHandlers';
 import makeGameHandlers from './handlers/makeGameHandlers';
 import mypageHandlers from './handlers/mypageHandlers';
+import bracketHandlers from './handlers/bracketHandlers';
 
 export const server = setupServer(
   ...testHandlers,
@@ -16,4 +17,5 @@ export const server = setupServer(
   ...statHandlers,
   ...makeGameHandlers,
   ...mypageHandlers,
+  ...bracketHandlers,
 );

--- a/src/@types/bracket.ts
+++ b/src/@types/bracket.ts
@@ -1,0 +1,4 @@
+export interface BracketHeader {
+  roundList: number[];
+  liveRound: number;
+}

--- a/src/components/Bracket/BracketHeaders.tsx
+++ b/src/components/Bracket/BracketHeaders.tsx
@@ -1,0 +1,57 @@
+import styled from '@emotion/styled';
+import { css } from '@emotion/react';
+
+import { BracketHeader } from '@type/bracket';
+
+interface Props extends BracketHeader {
+  curRound: number;
+  handleCurRound: (round: number) => void;
+}
+
+const BracketHeaders = (props: Props) => {
+  return (
+    <Header>
+      {props.roundList.map((round) => {
+        return (
+          <Button isClick={round === props.curRound} onClick={() => props.handleCurRound(round)}>
+            Round {round}
+            {round === props.liveRound && (
+              <svg
+                width='6'
+                height='6'
+                css={css`
+                  position: absolute;
+                  top: 1rem;
+                `}
+              >
+                <circle cx='3' cy='3' r='3' fill='red' />
+              </svg>
+            )}
+          </Button>
+        );
+      })}
+    </Header>
+  );
+};
+
+export default BracketHeaders;
+
+const Header = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const Button = styled.button<{ isClick: boolean }>`
+  width: 15rem;
+  height: 4rem;
+
+  position: relative;
+
+  border-width: ${(props) => (props.isClick ? '0.2rem' : '0.2rem 0 0 0.2rem')};
+  font-weight: ${(props) => (props.isClick ? '800' : '500')};
+
+  cursor: pointer;
+  border-color: #61677a;
+  background-color: #2c2c2c;
+  color: white;
+`;

--- a/src/pages/contents/[channelLink]/bracket.tsx
+++ b/src/pages/contents/[channelLink]/bracket.tsx
@@ -1,14 +1,36 @@
 import { GetServerSidePropsContext } from 'next';
-import axios from 'axios';
+import styled from '@emotion/styled';
+import { useState } from 'react';
 import { parse } from 'cookie';
+import axios from 'axios';
 
 import { SERVER_URL } from '@config/index';
+import { BracketHeader } from '@type/bracket';
+import BracketHeaders from '@components/Bracket/BracketHeaders';
 
-const Bracket = (props) => {
+interface Props {
+  data: BracketHeader;
+}
+
+const Bracket = (props: Props) => {
+  const [curRound, setCurRound] = useState<number>(1);
+
+  const handleCurRound = (round: number) => {
+    setCurRound(round);
+  };
+
   return (
-    <div>
-      <h2>Bracket!</h2>
-    </div>
+    <Container>
+      <BracketHeaders
+        roundList={props.data.roundList}
+        liveRound={props.data.liveRound}
+        curRound={curRound}
+        handleCurRound={handleCurRound}
+      />
+      <Content>
+        <h2>Bracket Content</h2>
+      </Content>
+    </Container>
   );
 };
 
@@ -21,7 +43,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
   try {
     const accessToken = cookies.accessToken;
 
-    const res = await axios<{ roundList: number[] }>({
+    const res = await axios<BracketHeader>({
       method: 'get',
       url: `${SERVER_URL}/api/match/${channelLink}`,
       headers: {
@@ -29,10 +51,13 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
       },
     });
 
+    const { roundList, liveRound } = res.data;
+
     return {
       props: {
         data: {
-          roundList: res.data.roundList,
+          roundList,
+          liveRound,
         },
       },
     };
@@ -46,3 +71,11 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
     };
   }
 };
+
+const Container = styled.div`
+  margin: 2rem 2rem;
+`;
+
+const Content = styled.div`
+  margin: 2rem 0;
+`;

--- a/src/pages/contents/[channelLink]/bracket.tsx
+++ b/src/pages/contents/[channelLink]/bracket.tsx
@@ -1,0 +1,48 @@
+import { GetServerSidePropsContext } from 'next';
+import axios from 'axios';
+import { parse } from 'cookie';
+
+import { SERVER_URL } from '@config/index';
+
+const Bracket = (props) => {
+  return (
+    <div>
+      <h2>Bracket!</h2>
+    </div>
+  );
+};
+
+export default Bracket;
+
+export const getServerSideProps = async (context: GetServerSidePropsContext) => {
+  const cookies = parse(context.req.headers.cookie || 'no-cookie');
+  const channelLink = context.params?.channelLink;
+
+  try {
+    const accessToken = cookies.accessToken;
+
+    const res = await axios<{ roundList: number[] }>({
+      method: 'get',
+      url: `${SERVER_URL}/api/match/${channelLink}`,
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    return {
+      props: {
+        data: {
+          roundList: res.data.roundList,
+        },
+      },
+    };
+  } catch (error) {
+    console.log(error);
+    return {
+      redirect: {
+        permanent: false,
+        destination: '/',
+      },
+    };
+  }
+};


### PR DESCRIPTION
## 🤠 개요

- closes: #66 
- 대진표 컴포넌트가 너무 커서 세분화해서 만들게요!

## 💫 설명
- 처음에는 대진표 컴포넌트를 하나의 이슈로 해결하려고 했는데 대진표 컴포넌트가 우리 서비스의 주 기능이고 매우 복잡해 여러개의 이슈로 나눠서 만들게요!

- 이번 이슈에서는 전체 라운드 수를 serverSideProps를 통해 가져오고 전체 라운드를 화면에 그리는 기능을 만들었어요.
- 이 때, 현재 진행 중인 라운드라면 빨간색 점을 통해 라이브임을 표시했어요.
- 또 현재 보고 있는 라운드라면 font를 굵게해서 알 수 있도록 했어요.


## 📷 스크린샷 (Optional)
![녹화_2023_08_27_20_21_40_49](https://github.com/TheUpperPart/leaguehub-frontend/assets/100738049/eaf0c21e-85a6-41df-ac0c-1915087a453e)
