### PR TITLE
Fix/#118: 채널 게시판에 대한 내용 수정 시 발생하는 문제점 해결

### DIFF
--- a/__mocks__/handlers/boardHandlers.ts
+++ b/__mocks__/handlers/boardHandlers.ts
@@ -120,6 +120,9 @@ const boardHandlers = [
 
     return res(ctx.json({ title, content }));
   }),
+  rest.post(SERVER_URL + '/api/channel/:channelLink/:boardId', (req, res, ctx) => {
+    return res(ctx.status(200), ctx.json({}));
+  }),
 ];
 
 export default boardHandlers;

--- a/src/components/Content/ContentModify.tsx
+++ b/src/components/Content/ContentModify.tsx
@@ -49,6 +49,7 @@ const ContentModify = ({ title, content, onUpdateContent }: ContentModifyProps) 
           <div
             css={css`
               text-align: start;
+              white-space: pre-line;
             `}
           >
             <PreviewTitle>{titleRef.current.value}</PreviewTitle>

--- a/src/components/Sidebar/BoardBar/BoardBody.tsx
+++ b/src/components/Sidebar/BoardBar/BoardBody.tsx
@@ -55,6 +55,7 @@ const BoardBody = ({ channelLink }: Props) => {
 
   const onClickBoard: MouseEventHandler<HTMLElement> = (e) => {
     const clickedId = e.currentTarget.dataset.id;
+    const clickedBoardTitle = e.currentTarget.dataset.boardTitle;
     if (e.target !== e.currentTarget) {
       return;
     }
@@ -64,7 +65,7 @@ const BoardBody = ({ channelLink }: Props) => {
 
     if (clickedId) {
       setSelected(clickedId);
-      handleBoard(channelLink, clickedId);
+      handleBoard(channelLink, clickedId, clickedBoardTitle as string);
       router.push(`/contents/${channelLink}/${clickedId}`);
     }
   };
@@ -78,7 +79,7 @@ const BoardBody = ({ channelLink }: Props) => {
     };
     data?.push(newBoard);
     selectBoardId(newBoard.boardId);
-    handleBoard(channelLink, newBoard.boardId);
+    handleBoard(channelLink, newBoard.boardId, res.boardTitle);
   };
 
   const selectBoardId = (boardId: string) => {
@@ -93,12 +94,10 @@ const BoardBody = ({ channelLink }: Props) => {
       selectBoardId(lastVisitBoardId);
       return;
     }
-  }, []);
 
-  useEffect(() => {
     if (isSuccess) {
       selectBoardId(data[0].boardId);
-      handleBoard(channelLink, data[0].boardId);
+      handleBoard(channelLink, data[0].boardId, data[0].boardTitle);
     }
   }, [channelLink, isSuccess]);
 
@@ -109,6 +108,7 @@ const BoardBody = ({ channelLink }: Props) => {
           <Wrapper
             key={board.boardId}
             data-id={board.boardId}
+            data-board-title={board.boardTitle}
             onClick={onClickBoard}
             isSelected={board.boardId === selected}
           >

--- a/src/components/providers/LastVisitedBoardListsProvider.tsx
+++ b/src/components/providers/LastVisitedBoardListsProvider.tsx
@@ -14,10 +14,10 @@ interface Props {
 const LastVisitedBoardListsProvider = ({ children }: Props) => {
   const [lastVisitedBoardIdLists, setLastVisitedBoardIdLists] = useState<LastVisitedBoardList>({});
 
-  const handleBoard = (key: keyof LastVisitedBoardList, boardId: string) => {
+  const handleBoard = (key: keyof LastVisitedBoardList, boardId: string, boardTitle: string) => {
     setLastVisitedBoardIdLists({
       ...lastVisitedBoardIdLists,
-      [key]: { boardId },
+      [key]: { boardId, boardTitle },
     });
   };
 

--- a/src/contexts/LastVisitedBoardListsContext.tsx
+++ b/src/contexts/LastVisitedBoardListsContext.tsx
@@ -3,7 +3,7 @@ import { createContext } from 'react';
 
 interface LastVisitedBoardListsContexts {
   lastVisitedBoardIdLists: LastVisitedBoardList;
-  handleBoard: (key: keyof LastVisitedBoardList, boardId: string) => void;
+  handleBoard: (key: keyof LastVisitedBoardList, boardId: string, boardTitle: string) => void;
 }
 
 const LastVisitedBoardListsContext = createContext<LastVisitedBoardListsContexts | null>(null);

--- a/src/pages/contents/[channelLink]/[boardId].tsx
+++ b/src/pages/contents/[channelLink]/[boardId].tsx
@@ -20,11 +20,12 @@ const boardContents = () => {
   const { channelLink, boardId } = router.query;
   const { channelPermission } = useChannels();
 
-  const fetchBoardContent = async (channelLink: string, boardId: string) => {
+  const fetchBoardContent = async () => {
     const res = await authAPI<Content>({
       method: 'get',
       url: `/api/channel/${channelLink}/${boardId}`,
     });
+    if (res.status !== 200) return router.push('/');
     setContents(res.data);
   };
 
@@ -43,9 +44,7 @@ const boardContents = () => {
       router.push('/');
       return;
     }
-    const channelLinkString = typeof channelLink === 'string' ? channelLink : channelLink[0];
-    const boardIdString = typeof boardId === 'string' ? boardId : boardId[0];
-    fetchBoardContent(channelLinkString, boardIdString);
+    fetchBoardContent();
   }, [channelLink, boardId]);
 
   return (

--- a/src/pages/contents/[channelLink]/[boardId].tsx
+++ b/src/pages/contents/[channelLink]/[boardId].tsx
@@ -12,6 +12,18 @@ export interface Content {
   content: string;
 }
 
+const updateData = async (channelLink: string, boardId: string, updatedContent: Content) => {
+  const res = await authAPI({
+    method: 'post',
+    url: `/api/channel/${channelLink}/${boardId}`,
+    data: {
+      title: updatedContent.title,
+      content: updatedContent.content,
+    },
+  });
+  return res;
+};
+
 const boardContents = () => {
   const [contents, setContents] = useState<Content>({ title: '', content: '' });
   const [isModify, setIsModify] = useState(false);
@@ -29,11 +41,17 @@ const boardContents = () => {
     setContents(res.data);
   };
 
-  const handleContentUpdate = ({ title, content }: Content) => {
+  const handleContentUpdate = async ({ title, content }: Content) => {
     const updatedContent: Content = {
       title,
       content,
     };
+    if (!channelLink) return;
+    const res = await updateData(channelLink as string, boardId as string, updatedContent);
+    if (res.status !== 200) {
+      alert('요청실패');
+      return;
+    }
     setContents(updatedContent);
     setIsModify(false);
   };

--- a/src/pages/contents/[channelLink]/[boardId].tsx
+++ b/src/pages/contents/[channelLink]/[boardId].tsx
@@ -63,6 +63,7 @@ const boardContents = () => {
             css={css`
               padding-top: 2rem;
               padding-bottom: 1rem;
+              white-space: pre-line;
             `}
           >
             <ReactMarkdown children={contents.content} />

--- a/src/pages/contents/[channelLink]/[boardId].tsx
+++ b/src/pages/contents/[channelLink]/[boardId].tsx
@@ -3,6 +3,7 @@ import ContentModify from '@components/Content/ContentModify';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import useChannels from '@hooks/useChannels';
+import useLastVisitedBoardLists from '@hooks/useLastVisitedBoardLists';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { ReactMarkdown } from 'react-markdown/lib/react-markdown';
@@ -31,6 +32,7 @@ const boardContents = () => {
   const router = useRouter();
   const { channelLink, boardId } = router.query;
   const { channelPermission } = useChannels();
+  const { handleBoard } = useLastVisitedBoardLists();
 
   const fetchBoardContent = async () => {
     const res = await authAPI<Content>({
@@ -54,6 +56,7 @@ const boardContents = () => {
     }
     setContents(updatedContent);
     setIsModify(false);
+    handleBoard(channelLink as string, boardId as string, title);
   };
 
   useEffect(() => {


### PR DESCRIPTION
## 🤠 개요

- closes: #118 
- 내용 수정 시 서버에 post 요청 보내는 로직 추가했어요
- 내용 수정하면 채널 게시판에 보이는 제목도 바로 변경되도록 추가했어요
- useLastVisitedBoardLists 전역상태관리에 해당 boardId 의 title 도 저장하도록 추가했어요
<!--
- 이슈번호
- 한줄 설명
- closes: #(이슈번호 입력해주세요)
  -->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
