### PR TITLE
Feat/#125 채널 참가하기 기능 추가

### DIFF
--- a/__mocks__/handlers/channelHandlers.ts
+++ b/__mocks__/handlers/channelHandlers.ts
@@ -2,7 +2,7 @@ import { rest } from 'msw';
 import { SERVER_URL } from '@config/index';
 import { ChannelCircleProps } from '@type/channelCircle';
 
-const getChannels: ChannelCi  rcleProps[][] = [
+const getChannels: ChannelCircleProps[][] = [
   [
     {
       channelLink: '123',

--- a/__mocks__/handlers/channelHandlers.ts
+++ b/__mocks__/handlers/channelHandlers.ts
@@ -64,6 +64,10 @@ const channelHandlers = [
   rest.post(SERVER_URL + '/api/channel', (req, res, ctx) => {
     return res(ctx.json(postChannels[0]));
   }),
+
+  rest.post(SERVER_URL + '/api/:channelLink/participant/observer', (req, res, ctx) => {
+    return res(ctx.json(postChannels[0]));
+  }),
 ];
 
 export default channelHandlers;

--- a/__test__/components/Sidebar/ChannelBar/SelectChannelType.test.tsx
+++ b/__test__/components/Sidebar/ChannelBar/SelectChannelType.test.tsx
@@ -11,17 +11,17 @@ jest.mock('next/router', () => require('next-router-mock'));
 describe('채널 추가 테스트', () => {
   const queryClient = new QueryClient();
 
+  const mockFn = jest.fn();
+
   it('초기에는 대회 개최 버튼과 대회 참여 버튼이 있다.', () => {
     render(
       <QueryClientProvider client={queryClient}>
         <ChannelsProvider>
-          <Modal>
-            <SelectChannelType
-              handleModal={() => {
-                return;
-              }}
-            />
-          </Modal>
+          <SelectChannelType
+            handleModal={() => {
+              return;
+            }}
+          />
         </ChannelsProvider>
       </QueryClientProvider>,
     );
@@ -35,13 +35,11 @@ describe('채널 추가 테스트', () => {
     render(
       <QueryClientProvider client={queryClient}>
         <ChannelsProvider>
-          <Modal>
-            <SelectChannelType
-              handleModal={() => {
-                return;
-              }}
-            />
-          </Modal>
+          <SelectChannelType
+            handleModal={() => {
+              return;
+            }}
+          />
         </ChannelsProvider>
       </QueryClientProvider>,
     );
@@ -56,13 +54,11 @@ describe('채널 추가 테스트', () => {
     render(
       <QueryClientProvider client={queryClient}>
         <ChannelsProvider>
-          <Modal>
-            <SelectChannelType
-              handleModal={() => {
-                return;
-              }}
-            />
-          </Modal>
+          <SelectChannelType
+            handleModal={() => {
+              return;
+            }}
+          />
         </ChannelsProvider>
       </QueryClientProvider>,
     );

--- a/__test__/components/Sidebar/ChannelBar/SelectChannelType.test.tsx
+++ b/__test__/components/Sidebar/ChannelBar/SelectChannelType.test.tsx
@@ -3,19 +3,27 @@ import SelectChannelType from '@components/Sidebar/ChannelBar/SelectChannelType'
 import { render, screen } from '@testing-library/react';
 import mockRouter from 'next-router-mock';
 import userEvent from '@testing-library/user-event';
+import ChannelsProvider from '@components/providers/ChannelsProvider';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 jest.mock('next/router', () => require('next-router-mock'));
 
 describe('채널 추가 테스트', () => {
+  const queryClient = new QueryClient();
+
   it('초기에는 대회 개최 버튼과 대회 참여 버튼이 있다.', () => {
     render(
-      <Modal>
-        <SelectChannelType
-          handleModal={() => {
-            return;
-          }}
-        />
-      </Modal>,
+      <QueryClientProvider client={queryClient}>
+        <ChannelsProvider>
+          <Modal>
+            <SelectChannelType
+              handleModal={() => {
+                return;
+              }}
+            />
+          </Modal>
+        </ChannelsProvider>
+      </QueryClientProvider>,
     );
 
     const btns = screen.getAllByRole('button');
@@ -25,13 +33,17 @@ describe('채널 추가 테스트', () => {
 
   it('대회 개최하기 버튼을 누르면 make-channel 페이지로 이동한다.', async () => {
     render(
-      <Modal>
-        <SelectChannelType
-          handleModal={() => {
-            return;
-          }}
-        />
-      </Modal>,
+      <QueryClientProvider client={queryClient}>
+        <ChannelsProvider>
+          <Modal>
+            <SelectChannelType
+              handleModal={() => {
+                return;
+              }}
+            />
+          </Modal>
+        </ChannelsProvider>
+      </QueryClientProvider>,
     );
 
     const makeBtn = screen.getByText('대회 개최');
@@ -42,13 +54,17 @@ describe('채널 추가 테스트', () => {
 
   it('대회 참여하기 버튼을 누르면 참여 코드를 입력하는 input이 표시된다.', async () => {
     render(
-      <Modal>
-        <SelectChannelType
-          handleModal={() => {
-            return;
-          }}
-        />
-      </Modal>,
+      <QueryClientProvider client={queryClient}>
+        <ChannelsProvider>
+          <Modal>
+            <SelectChannelType
+              handleModal={() => {
+                return;
+              }}
+            />
+          </Modal>
+        </ChannelsProvider>
+      </QueryClientProvider>,
     );
 
     const enterBtn = screen.getByText('대회 참여');


### PR DESCRIPTION
## 🤠 개요

- closes: #125 
- 채널 참가하기 기능을 추가했어요.

## 💫 설명

- 사용자는 다른 채널의 참가 코드를 입력하면 참가할 수 있는 기능을 추가했어요.
- 추가한 채널은 바로 좌측 채널바에 나타나도록 했어요.
- mock data와 api도 추가했어요.


## 📷 스크린샷 (Optional)
![녹화_2023_09_09_23_43_54_131](https://github.com/TheUpperPart/leaguehub-frontend/assets/100738049/1c88905d-34d8-4526-8758-772e7aaed4d7)
