### PR TITLE
Feat/#127 프로필 및 채널에 이미지 추가

### DIFF
--- a/__test__/components/Sidebar/ChannelCircle/ChannelCircle.test.tsx
+++ b/__test__/components/Sidebar/ChannelCircle/ChannelCircle.test.tsx
@@ -6,20 +6,20 @@ describe('채널 테스트', () => {
   const initalState: ChannelCircleProps = {
     channelLink: 'ab5gx',
     title: '부경대 총장기',
-    category: 0,
+    gameCategory: 0,
     customChannelIndex: 0,
   };
 
   it('채널 이름을 가진 컴포넌트가 있다.', () => {
     render(<ChannelCircle {...initalState} />);
-    const nameEl = screen.getByText('부경대 총장기');
+    const nameEl = screen.getByText('부경');
     expect(nameEl).toBeInTheDocument();
   });
 
   const initalState2 = {
     channelLink: 'ab5gx',
     title: '부경대 총장기',
-    category: 0,
+    gameCategory: 0,
     imgSrc: '1.jpeg',
     customChannelIndex: 1,
   };

--- a/src/@types/channelCircle.ts
+++ b/src/@types/channelCircle.ts
@@ -1,7 +1,7 @@
 export interface ChannelCircleProps {
   channelLink: string;
   title: string;
-  category: number;
+  gameCategory: number;
   imgSrc?: string;
   customChannelIndex: number;
 }

--- a/src/components/Sidebar/ChannelBar/ChannelBar.tsx
+++ b/src/components/Sidebar/ChannelBar/ChannelBar.tsx
@@ -38,31 +38,38 @@ const ChannelBar = ({ channels, updateSelectedChannel }: ChannelBarProps) => {
           {(provided, snapshot) => (
             <DropContainer ref={provided.innerRef} {...provided.droppableProps}>
               {channels &&
-                channels.map(({ channelLink, title, category, customChannelIndex }, index) => (
-                  <Draggable draggableId={'channel-' + channelLink} index={index} key={channelLink}>
-                    {(provided, snapshot) => (
-                      <div
-                        ref={provided.innerRef}
-                        {...provided.draggableProps}
-                        {...provided.dragHandleProps}
-                        css={css`
-                          margin: 0 auto;
-                          display: flex;
-                          align-items: center;
-                          justify-content: center;
-                        `}
-                        onClick={() => updateSelectedChannel(channelLink)}
-                      >
-                        <ChannelCircle
-                          channelLink={channelLink}
-                          title={title}
-                          category={category}
-                          customChannelIndex={customChannelIndex}
-                        />
-                      </div>
-                    )}
-                  </Draggable>
-                ))}
+                channels.map(
+                  ({ channelLink, title, gameCategory, customChannelIndex, imgSrc }, index) => (
+                    <Draggable
+                      draggableId={'channel-' + channelLink}
+                      index={index}
+                      key={channelLink}
+                    >
+                      {(provided, snapshot) => (
+                        <div
+                          ref={provided.innerRef}
+                          {...provided.draggableProps}
+                          {...provided.dragHandleProps}
+                          css={css`
+                            margin: 0 auto;
+                            display: flex;
+                            align-items: center;
+                            justify-content: center;
+                          `}
+                          onClick={() => updateSelectedChannel(channelLink)}
+                        >
+                          <ChannelCircle
+                            channelLink={channelLink}
+                            title={title}
+                            gameCategory={gameCategory}
+                            customChannelIndex={customChannelIndex}
+                            imgSrc={imgSrc}
+                          />
+                        </div>
+                      )}
+                    </Draggable>
+                  ),
+                )}
               {provided.placeholder}
             </DropContainer>
           )}

--- a/src/components/Sidebar/ChannelCircle/ChannelCircle.tsx
+++ b/src/components/Sidebar/ChannelCircle/ChannelCircle.tsx
@@ -44,8 +44,8 @@ const ChannelBtn = styled.div<{ url?: string }>`
     css`
       background-image: url(${prop.url});
       background-size: 100% 75%;
-      background-position: center top; /* 배경 이미지를 가운데 정렬하고 위에서부터 정렬합니다. */
-      background-repeat: no-repeat; /* 배경 이미지 반복을 비활성화합니다. */
+      background-position: center top;
+      background-repeat: no-repeat;
     `}
 
   &:hover {

--- a/src/components/Sidebar/ChannelCircle/ChannelCircle.tsx
+++ b/src/components/Sidebar/ChannelCircle/ChannelCircle.tsx
@@ -7,14 +7,14 @@ import { ChannelCircleProps } from 'src/@types/channelCircle';
 const ChannelCircle = ({
   channelLink,
   title,
-  category,
+  gameCategory,
   imgSrc,
   customChannelIndex,
 }: ChannelCircleProps) => {
   return (
     <ChannelBtn url={imgSrc}>
-      <ChannelName>{title}</ChannelName>
-      <ChannelGame>{GameEnum[category]}</ChannelGame>
+      <ChannelName>{imgSrc ? '' : title.substring(0, 2)}</ChannelName>
+      <ChannelGame>{GameEnum[gameCategory]}</ChannelGame>
     </ChannelBtn>
   );
 };
@@ -43,7 +43,9 @@ const ChannelBtn = styled.div<{ url?: string }>`
     prop.url &&
     css`
       background-image: url(${prop.url});
-      background-size: cover;
+      background-size: 100% 75%;
+      background-position: center top; /* 배경 이미지를 가운데 정렬하고 위에서부터 정렬합니다. */
+      background-repeat: no-repeat; /* 배경 이미지 반복을 비활성화합니다. */
     `}
 
   &:hover {

--- a/src/components/providers/ProfileProvider.tsx
+++ b/src/components/providers/ProfileProvider.tsx
@@ -6,12 +6,17 @@ import { Profile } from '@type/profile';
 import authAPI from '@apis/authAPI';
 import Cookies from 'js-cookie';
 
+interface ProfileAPI {
+  nickName: string;
+  profileImageUrl: string;
+}
+
 interface ProfileProviderProps {
   children: React.ReactNode;
 }
 
 const fetchProfile = async () => {
-  const res = await authAPI<Profile>({
+  const res = await authAPI<ProfileAPI>({
     method: 'get',
     url: '/api/member/profile',
   });
@@ -26,7 +31,7 @@ const ProfileProvider = ({ children }: ProfileProviderProps) => {
   const [profile, setProfile] = useState<Profile | null>(null);
 
   // 유저의 프로필 가져오기
-  const profileQuery = useQuery<Profile>({
+  const profileQuery = useQuery<ProfileAPI>({
     queryKey: ['getProfile'],
     queryFn: fetchProfile,
     enabled: isHaveAccessToken ? true : false, // 액세스 토큰이 있으면 query 요청
@@ -35,7 +40,10 @@ const ProfileProvider = ({ children }: ProfileProviderProps) => {
   // 프로필 데이터를 가져왔다면
   useEffect(() => {
     if (profileQuery.data) {
-      setProfile({ ...profileQuery.data });
+      setProfile({
+        nickname: profileQuery.data.nickName,
+        profileUrl: profileQuery.data?.profileImageUrl,
+      });
     }
   }, [profileQuery.data]);
 


### PR DESCRIPTION
## 🤠 개요

- closes: #127 
- 프로필과 채널에 이미지가 표시되도록 변경했어요.


## 💫 설명
- 기존에 프로필을 불러오는 API에서 응답 형식이 변경되어서 해당 형식을 적용했어요.
- 채널의 경우 이미지가 있으면 해당 이미지를 보여주고 채널 이름을 숨겨요
- 만약 채널에 이미지가 없다면 채널 이름의 두 글자만 표시되도록 우선 변경했어요.



- 채널 이미지와 관련해서 의논할 부분이 생겼어요.
  - 지금은 원형 전체의 75퍼센트가 사진이고 25퍼센트가 게임 종류를 나타내요.

  - 왼쪽부터 1, 2, 3이라고 할 때 1번이 원본 사진이라고 했을 때 원래라면 2번 처럼 원본 사진의 75퍼센트만 보이고 25퍼센트를 가리면서 게임 종류를 나타내야하는데 지금은 3번처럼 전체 사진을 75%에 맞게 크기를 줄여서 사용해요.

  - 이 부분을 어떻게 2번 처럼 표시할 지 모르겠어요. 


<img width="806" alt="ddd" src="https://github.com/TheUpperPart/leaguehub-frontend/assets/100738049/b40ee2a5-d12b-4d8a-9c01-d9039596977c">


- 지금 아래와 같은 구조로 채널 컴포넌트를 만들었어요.

```typescript
<ChannelBtn>
   <div>채널 제목</div>
   <div>게임 종류</div>
</ChannelBtn>


const ChannelBtn = styled.button<{ url?: string }>`
  background: linear-gradient(to bottom, #344051 75%, #202b37 25%);
  ${(prop) =>
    prop.url &&
    css`
      background-image: url(${prop.url});
      background-size: 100% 75%;
      background-position: center top; /* 배경 이미지를 가운데 정렬하고 위에서부터 정렬합니다. */
      background-repeat: no-repeat; /* 배경 이미지 반복을 비활성화합니다. */
    `}
  &:hover {
    border-radius: 30%;
  }
`;

```

- 원형 모양을 그려야해서 상위 ChannelBtn에 border-radius: 50%로 원형 모양을 그렸고 ChannelBtn에서 배경색을 미리 지정했어요.
  - ChannelBtn이 아니라 하위 div에서 배경색을 지정하려고 했는데 저기 반원과 비슷한 모양으로 border-radius를 주기 힘들더라구요.




## 📷 스크린샷 (Optional)
<img width="472" alt="445" src="https://github.com/TheUpperPart/leaguehub-frontend/assets/100738049/ce1b1ced-3d2e-4706-9f7d-80221caf7fba">