### PR TITLE
Feat/#131 채널 생성 시 이미지 업로드 구현

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    domains: ['localhost', 'k.kakaocdn.net', 's3.ap-northeast-2.amazonaws.com'],
+    domains: ['localhost', 'k.kakaocdn.net', 'league-hub-s3.s3.ap-northeast-2.amazonaws.com'],
   },
   reactStrictMode: true,
 };

--- a/src/components/MakeChannel/SelectRule.tsx
+++ b/src/components/MakeChannel/SelectRule.tsx
@@ -7,8 +7,13 @@ import ToggleButton from '@components/Button/Toggle/index';
 import useMakeGame from '@hooks/useMakeGame';
 import { GameMethod } from '@constants/MakeGame';
 import CustomRule from './CustomRule';
+import { useRef, useState } from 'react';
+import authAPI from '@apis/authAPI';
+import Image from 'next/image';
 
 const SelectRule = () => {
+  const [imageUrl, setImageUrl] = useState<string>();
+
   const {
     matchFormat,
     handleMatchFormat,
@@ -18,7 +23,33 @@ const SelectRule = () => {
     handleIsUseCustomRule,
     customRule,
     handleCustomRule,
+    handleImgUrl,
   } = useMakeGame();
+
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const fetchUploadChannelImage = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!e.target.files) {
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append('uploadImage', e.target.files[0]);
+
+    try {
+      const res = await authAPI<{ imgUrl: string }>({
+        method: 'post',
+        url: `/api/image`,
+        data: formData,
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      });
+
+      setImageUrl(res.data.imgUrl);
+      handleImgUrl(res.data.imgUrl);
+    } catch (error) {}
+  };
 
   return (
     <Container>
@@ -86,6 +117,10 @@ const SelectRule = () => {
               </div>
             )}
           </CustomContainer>
+        </Rule>
+        <Rule>
+          <input type='file' accept='image/*' ref={inputRef} onChange={fetchUploadChannelImage} />
+          {imageUrl && <Image width={50} height={50} src={imageUrl} alt='channelImage' />}
         </Rule>
       </Wrapper>
     </Container>

--- a/src/components/providers/MakeGameProvider.tsx
+++ b/src/components/providers/MakeGameProvider.tsx
@@ -10,7 +10,6 @@ interface MakeGameProps {
 export interface BasicInfo {
   title: string;
   participationNum: number;
-  channelImageUrl: string;
 }
 
 export interface IsUseCustomRule {
@@ -41,7 +40,7 @@ const MakeGameProvider = ({ children }: MakeGameProps) => {
   const [basicInfo, setBasicInfo] = useState<BasicInfo>(initBasicInfo);
   const [isUseCustomRule, setIsUseCustomRule] = useState<IsUseCustomRule>(initIsUseCustomRule);
   const [customRule, setCustomRule] = useState<CustomRule>(initCustomRule);
-
+  const [channelImgUrl, setChannelImgUrl] = useState<string>('');
   const handleCurrentStep = () => {
     if (currentStep < 3) {
       setCurrentStep((prev) => prev + 1);
@@ -72,6 +71,10 @@ const MakeGameProvider = ({ children }: MakeGameProps) => {
     setCustomRule({ ...customRule, [type]: value });
   };
 
+  const handleImgUrl = (url: string) => {
+    setChannelImgUrl(url);
+  };
+
   const resetState = () => {
     setCurrentStep(initCurrentStep);
     setGameCategory(initCategory);
@@ -79,6 +82,7 @@ const MakeGameProvider = ({ children }: MakeGameProps) => {
     setBasicInfo(initBasicInfo);
     setIsUseCustomRule(initIsUseCustomRule);
     setCustomRule(initCustomRule);
+    setChannelImgUrl('');
   };
 
   const isHaveBlankValue = () => {
@@ -108,6 +112,8 @@ const MakeGameProvider = ({ children }: MakeGameProps) => {
     handleCustomRule,
     resetState,
     isHaveBlankValue,
+    channelImgUrl,
+    handleImgUrl,
   };
 
   return <MakeGameContext.Provider value={contextValue}>{children}</MakeGameContext.Provider>;

--- a/src/components/providers/MakeGameProvider.tsx
+++ b/src/components/providers/MakeGameProvider.tsx
@@ -32,6 +32,7 @@ const MakeGameProvider = ({ children }: MakeGameProps) => {
     initBasicInfo,
     initIsUseCustomRule,
     initCustomRule,
+    initChannelImgUrl,
   } = TFTInitialValue;
 
   const [currentStep, setCurrentStep] = useState<number>(initCurrentStep);
@@ -82,7 +83,7 @@ const MakeGameProvider = ({ children }: MakeGameProps) => {
     setBasicInfo(initBasicInfo);
     setIsUseCustomRule(initIsUseCustomRule);
     setCustomRule(initCustomRule);
-    setChannelImgUrl('');
+    setChannelImgUrl(initChannelImgUrl);
   };
 
   const isHaveBlankValue = () => {

--- a/src/constants/MakeGame.ts
+++ b/src/constants/MakeGame.ts
@@ -19,6 +19,7 @@ interface TFTInitial {
   initBasicInfo: BasicInfo;
   initIsUseCustomRule: IsUseCustomRule;
   initCustomRule: CustomRule;
+  initChannelImgUrl: string;
 }
 
 export const TFTInitialValue: TFTInitial = {
@@ -28,7 +29,6 @@ export const TFTInitialValue: TFTInitial = {
   initBasicInfo: {
     title: '',
     participationNum: 0,
-    channelImageUrl: '',
   },
   initIsUseCustomRule: {
     tierMax: false,
@@ -40,4 +40,5 @@ export const TFTInitialValue: TFTInitial = {
     tierMin: 0,
     playCountMin: 50,
   },
+  initChannelImgUrl: '',
 };

--- a/src/contexts/MakeGameContext.tsx
+++ b/src/contexts/MakeGameContext.tsx
@@ -16,6 +16,8 @@ interface MakeGameState {
   handleCustomRule: (type: keyof CustomRule, value: number) => void;
   resetState: () => void;
   isHaveBlankValue: () => boolean;
+  channelImgUrl: string;
+  handleImgUrl: (url: string) => void;
 }
 
 const MakeGameContext = createContext<MakeGameState | null>(null);

--- a/src/pages/make-channel.tsx
+++ b/src/pages/make-channel.tsx
@@ -23,6 +23,7 @@ const MakeChannel = () => {
     customRule,
     resetState,
     isHaveBlankValue,
+    channelImgUrl,
   } = useMakeGame();
 
   const { addChannel } = useChannels();
@@ -47,6 +48,7 @@ const MakeChannel = () => {
           tierMin: customRule.tierMin,
           playCount: isUseCustomRule.playCount,
           playCountMin: customRule.playCountMin,
+          channelImageUrl: channelImgUrl,
         },
       });
       resetState();


### PR DESCRIPTION
## 🤠 개요

- closes: #131 
- 채널을 생성할 때 이미지 업로드를 할 수 있는 기능을 구현했어요.

## 💫 설명
- formdata로 서버에 이미지를 보내고 이미지를 저장하는 기능을 구현했어요.
- 현재 미리보기, 업로드 버튼에 스타일은 적용하지 않았어요. 추후에 마이페이지 이미지 수정 기능을 추가하면서 디자인을 추가할게요.

-->

## 📷 스크린샷 (Optional)
<img width="477" alt="Screenshot 2023-09-10 at 5 53 09 PM" src="https://github.com/TheUpperPart/leaguehub-frontend/assets/100738049/c2d2b262-88cc-4b2c-bc3b-38e9240ff18e">


