### PR TITLE
Feat: 헤더 드롭다운 메뉴 추가

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -2,14 +2,18 @@ import { useRouter } from 'next/router';
 import styled from '@emotion/styled';
 
 import Icon from '@components/Icon';
-import { useContext } from 'react';
+import { useContext, useState } from 'react';
 import Image from 'next/image';
 import ProfileContext from '@contexts/ProfileContext';
+import authAPI from '@apis/authAPI';
+import Cookies from 'js-cookie';
 
 const Header = () => {
   const router = useRouter();
 
   const profileContext = useContext(ProfileContext);
+
+  const [clickDropdown, setClickDropdown] = useState<boolean>(false);
 
   // 로그인을 누른 url 저장
   const handleLink = () => {
@@ -18,11 +22,29 @@ const Header = () => {
     }
   };
 
+  const handleDropDown = () => {
+    setClickDropdown((prev) => !prev);
+  };
+
+  const moveToMypage = () => {
+    router.push('/mypage');
+  };
+
+  const handleLogout = async () => {
+    try {
+      const res = await authAPI({ method: 'post', url: '/api/member/logout' });
+      Cookies.remove('accessToken');
+      Cookies.remove('refreshToken');
+
+      router.push('/');
+    } catch (error) {}
+  };
+
   return (
     <Headers>
       <Container>
         {profileContext?.profile ? (
-          <LoginBtn onClick={handleLink}>
+          <LoginBtn onClick={handleDropDown}>
             <ProfileImg
               src={profileContext.profile.profileUrl}
               width={24}
@@ -30,6 +52,10 @@ const Header = () => {
               alt='profile'
             />
             <Text>{profileContext.profile.nickname}</Text>
+            <DropDown click={clickDropdown}>
+              <DropList onClick={moveToMypage}>마이페이지</DropList>
+              <DropList onClick={handleLogout}>로그아웃</DropList>
+            </DropDown>
           </LoginBtn>
         ) : (
           <LoginBtn onClick={handleLink}>
@@ -56,6 +82,8 @@ const Container = styled.div`
   display: flex;
   align-items: center;
   justify-content: flex-end;
+
+  position: relative;
 `;
 
 const ProfileImg = styled(Image)`
@@ -77,4 +105,32 @@ const LoginBtn = styled.button`
 const Text = styled.div`
   font-size: 1.4rem;
   font-weight: 900;
+`;
+
+const DropDown = styled.ul<{ click: boolean }>`
+  position: absolute;
+
+  display: ${(prop) => (prop.click ? 'block' : 'none')};
+
+  width: 10rem;
+
+  top: 5.5rem;
+  right: 0rem;
+
+  color: black;
+`;
+
+const DropList = styled.li`
+  list-style: none;
+
+  align-items: center;
+  justify-content: center;
+
+  display: flex;
+
+  background-color: #344051;
+  color: white;
+
+  height: 4rem;
+  border: 1px solid black;
 `;


### PR DESCRIPTION
## 🤠 개요

- closes: #128 
- 헤더를 클릭했을 때 헤더 드롭다운 메뉴를 추가했어요.

## 💫 설명
- 로그인 되어있을 땐 이름과 이미지를 클릭하면 드롭다운 메뉴를 만들었어요.
  - 현재 로그아웃을 하면 서버에 로그아웃을 요청하고 cookie에서 accessToken과 refreshToken을 제거했는데 profileContext를 초기화 하지 않았어요.
  - profileContext의 경우 앞선 pr에서 수정된 부분이 있어서 해당 pr이 머지되면 초기화 기능을 추가할게요.
 

## 📷 스크린샷 (Optional)
![ㅇㅇㅇㅇ](https://github.com/TheUpperPart/leaguehub-frontend/assets/100738049/c4a2e4fb-8e8c-4ead-b9ba-bc9139006d6c)