### PR TITLE
Feat/#144 라운드별 매치 횟수를 설정 및 대진표 기본 디자인

### DIFF
--- a/__mocks__/constants/matchRoundMock.ts
+++ b/__mocks__/constants/matchRoundMock.ts
@@ -1,11 +1,11 @@
 import { BracketContents } from '@type/bracket';
 
 interface mockRoundData {
-  [key: string]: BracketContents;
+  [key: number]: BracketContents;
 }
 
 export const matchRoundMock: mockRoundData = {
-  '1': {
+  1: {
     myGameId: 'NO_DATA',
     matchInfoDtoList: [
       {
@@ -439,7 +439,7 @@ export const matchRoundMock: mockRoundData = {
       },
     ],
   },
-  '2': {
+  2: {
     myGameId: 'NO_DATA',
     matchInfoDtoList: [
       {
@@ -658,7 +658,7 @@ export const matchRoundMock: mockRoundData = {
       },
     ],
   },
-  '3': {
+  3: {
     myGameId: 'NO_DATA',
     matchInfoDtoList: [
       {
@@ -773,7 +773,7 @@ export const matchRoundMock: mockRoundData = {
       },
     ],
   },
-  '4': {
+  4: {
     myGameId: 'NO_DATA',
     matchInfoDtoList: [
       {

--- a/__mocks__/handlers/bracketHandlers.ts
+++ b/__mocks__/handlers/bracketHandlers.ts
@@ -1,7 +1,13 @@
 import { SERVER_URL } from '@config/index';
 import { matchRoundMock } from '@mocks/constants/matchRoundMock';
+import { MatchCountList } from '@type/channelConfig';
 import { rest } from 'msw';
 
+const channelRoundList: MatchCountList[] = [
+  {
+    roundCountList: [2, 3, 4, 5],
+  },
+];
 const bracketHandlers = [
   rest.get(SERVER_URL + '/api/match/:channelLink', (req, res, ctx) => {
     const { channelLink } = req.params;
@@ -9,12 +15,18 @@ const bracketHandlers = [
     return res(ctx.json({ roundList: [1, 2, 3, 4], liveRound: 1 }));
   }),
 
-  rest.get(SERVER_URL + '/api/match/:channelLink/:matchRound', (req, res, ctx) => {
+  rest.get(SERVER_URL + '/api/match/:channelLink/:matchRound(\\d+)', (req, res, ctx) => {
     const { channelLink, matchRound } = req.params;
 
-    if (typeof matchRound === 'string') {
-      return res(ctx.json(matchRoundMock[matchRound]));
-    }
+    return res(ctx.json(matchRoundMock[Number(matchRound)]));
+  }),
+
+  rest.get(SERVER_URL + '/api/match/:channelLink/count', (req, res, ctx) => {
+    return res(ctx.json(channelRoundList[0]));
+  }),
+
+  rest.post(SERVER_URL + '/api/match/:channelLink/count', (req, res, ctx) => {
+    return res(ctx.json({ message: '채널 재설정 완료' }));
   }),
 ];
 

--- a/src/@types/channelConfig.ts
+++ b/src/@types/channelConfig.ts
@@ -1,0 +1,3 @@
+export interface MatchCountList {
+  roundCountList: number[];
+}

--- a/src/@types/icon.ts
+++ b/src/@types/icon.ts
@@ -10,4 +10,6 @@ export type IconKind =
   | 'clock'
   | 'refresh'
   | 'sendEmail'
-  | 'modify';
+  | 'modify'
+  | 'setting'
+  | 'cancel';

--- a/src/components/Bracket/BracketContents.tsx
+++ b/src/components/Bracket/BracketContents.tsx
@@ -39,29 +39,33 @@ const BracketContents = (props: Props) => {
           return (
             <MatchContainer>
               <MatchHeader>
-                <MatchHeaderRound>R{match.matchRoundCount}</MatchHeaderRound>
+                <MatchHeaderRound>M{match.matchRoundCount}</MatchHeaderRound>
                 <MatchHeaderName>{match.matchName}</MatchHeaderName>
                 <MatchHeaderMore>자세히</MatchHeaderMore>
               </MatchHeader>
               <MatchContent>
-                {match.matchPlayerInfoList.map((user) => {
-                  return (
-                    <UserContainer myself={user.gameId === data.myGameId}>
-                      <UserImgContainer>
-                        {user.profileSrc ? (
-                          <UserImg src={user.profileSrc} alt='profile' width={30} height={30} />
-                        ) : (
-                          <UserNameImg>
-                            <UserNameImgText>{user.gameId.substring(0, 2)}</UserNameImgText>
-                          </UserNameImg>
-                        )}
-                      </UserImgContainer>
+                {match.matchPlayerInfoList.length === 0 ? (
+                  <MatchNoGame>아직 대진표가 생성되지 않았어요 :(</MatchNoGame>
+                ) : (
+                  match.matchPlayerInfoList.map((user) => {
+                    return (
+                      <UserContainer myself={user.gameId === data.myGameId}>
+                        <UserImgContainer>
+                          {user.profileSrc ? (
+                            <UserImg src={user.profileSrc} alt='profile' width={30} height={30} />
+                          ) : (
+                            <UserNameImg>
+                              <UserNameImgText>{user.gameId.substring(0, 2)}</UserNameImgText>
+                            </UserNameImg>
+                          )}
+                        </UserImgContainer>
 
-                      <UserName>{user.gameId}</UserName>
-                      <UserScore>{user.score}</UserScore>
-                    </UserContainer>
-                  );
-                })}
+                        <UserName>{user.gameId}</UserName>
+                        <UserScore>{user.score}</UserScore>
+                      </UserContainer>
+                    );
+                  })
+                )}
               </MatchContent>
             </MatchContainer>
           );
@@ -78,6 +82,8 @@ const Container = styled.div``;
 const Header = styled.div``;
 
 const Content = styled.div`
+  position: relative;
+
   display: grid;
 
   max-width: 100rem;
@@ -168,6 +174,19 @@ const MatchContent = styled.div`
   row-gap: 0.5rem;
 
   flex-direction: column;
+`;
+
+const MatchNoGame = styled.div`
+  height: 35rem;
+  width: 21rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #b4b4b3;
+  opacity: 0.6;
+
+  font-size: 1.8 rem;
+  color: black;
 `;
 
 const UserContainer = styled.div<{ myself: boolean }>`

--- a/src/components/Icon/index.tsx
+++ b/src/components/Icon/index.tsx
@@ -13,6 +13,8 @@ import {
   MdRefresh,
   MdSend,
   MdModeEdit,
+  MdSettings,
+  MdCancel,
 } from 'react-icons/md';
 import { MouseEventHandler } from 'react';
 
@@ -29,6 +31,8 @@ const ICON: { [key in IconKind]: IconType } = {
   refresh: MdRefresh,
   sendEmail: MdSend,
   modify: MdModeEdit,
+  setting: MdSettings,
+  cancel: MdCancel,
 };
 
 interface IconProps {

--- a/src/components/Modal/ModifyChannel/ModifyChannel.tsx
+++ b/src/components/Modal/ModifyChannel/ModifyChannel.tsx
@@ -1,8 +1,8 @@
-import authAPI from '@apis/authAPI';
-import { css } from '@emotion/react';
+import Icon from '@components/Icon';
+import BasicInfoChannel from '@components/ModifyChannel/BasicInfoChannel';
+import BracketInfoChannel from '@components/ModifyChannel/BracketInfoChannel';
 import styled from '@emotion/styled';
-import { useRef } from 'react';
-
+import { useState } from 'react';
 interface ModifyChannelProps {
   channelLink: string;
   leagueTitle: string;
@@ -10,68 +10,38 @@ interface ModifyChannelProps {
   onClose: (leagueTitle?: string, maxPlayer?: number) => void;
 }
 
-const ModifyChannel = ({ channelLink, leagueTitle, maxPlayer, onClose }: ModifyChannelProps) => {
-  const leagueTitleRef = useRef<HTMLInputElement>(null);
-  const maxPlayerRef = useRef<HTMLInputElement>(null);
+type MenuList = 'basicInfo' | 'bracketInfo';
 
-  const onClickSubmit = async () => {
-    console.log(leagueTitleRef.current?.value, maxPlayerRef.current?.value);
-    if (!leagueTitleRef.current || !maxPlayerRef.current) return;
-    const updatedLeagueTitle = leagueTitleRef.current.value;
-    const updatedMaxPlayer = parseInt(maxPlayerRef.current.value, 10);
-    if (isNaN(updatedMaxPlayer)) {
-      alert('최대인원수를 숫자로 입력해주세요');
-      return;
-    }
-    if (!confirm('리그를 수정하시겠습니까?')) return;
-    const res = await authAPI({
-      method: 'post',
-      url: `/api/channel/${channelLink}`,
-      data: {
-        title: updatedLeagueTitle,
-        maxPlayer: updatedMaxPlayer,
-      },
-    });
-    if (res.status !== 200) return;
-    alert('정보가 수정되었습니다');
-    onClose(updatedLeagueTitle, updatedMaxPlayer);
+const ModifyChannel = ({ channelLink, leagueTitle, maxPlayer, onClose }: ModifyChannelProps) => {
+  const [selectedMenu, setSelectedMenu] = useState<MenuList>('basicInfo');
+
+  const handleSelectedMenu = (menu: MenuList) => {
+    setSelectedMenu(menu);
   };
 
   return (
     <Container>
-      <Wrapper
-        css={css`
-          padding-bottom: 3rem;
-        `}
-      >
-        <h1>리그 수정하기</h1>
-      </Wrapper>
-      <Wrapper>
-        <FlexWrapper>리그 제목</FlexWrapper>
-        <FlexWrapper>
-          <Input
-            type='text'
-            placeholder='리그 제목을 입력해주세요'
-            ref={leagueTitleRef}
-            defaultValue={leagueTitle}
+      <Sidebar>
+        <SidebarContent onClick={() => handleSelectedMenu('basicInfo')}>
+          대회 기본 정보 수정
+        </SidebarContent>
+        <SidebarContent onClick={() => handleSelectedMenu('bracketInfo')}>
+          대진표 수정
+        </SidebarContent>
+      </Sidebar>
+      <MainContent>
+        {selectedMenu === 'basicInfo' && (
+          <BasicInfoChannel
+            channelLink={channelLink}
+            leagueTitle={leagueTitle}
+            maxPlayer={maxPlayer}
           />
-        </FlexWrapper>
-      </Wrapper>
-      <Wrapper>
-        <FlexWrapper>최대 참여자 인원</FlexWrapper>
-        <FlexWrapper>
-          <Input
-            type='text'
-            placeholder='최대 인원을 설정해주세요'
-            ref={maxPlayerRef}
-            defaultValue={maxPlayer}
-          />
-        </FlexWrapper>
-      </Wrapper>
-      <ButtonWrapper>
-        <SubmitButton onClick={() => onClose()}>취소</SubmitButton>
-        <SubmitButton onClick={onClickSubmit}>수정하기</SubmitButton>
-      </ButtonWrapper>
+        )}
+        {selectedMenu === 'bracketInfo' && <BracketInfoChannel />}
+      </MainContent>
+      <CloseButtonContainer>
+        <Icon kind='cancel' size={40} onClick={() => onClose()} />
+      </CloseButtonContainer>
     </Container>
   );
 };
@@ -79,58 +49,42 @@ const ModifyChannel = ({ channelLink, leagueTitle, maxPlayer, onClose }: ModifyC
 export default ModifyChannel;
 
 const Container = styled.div`
-  color: black;
-  padding: 5%;
-`;
+  width: 100vw;
+  height: 100vh;
+  background-color: white;
 
-const Wrapper = styled.div`
   display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
-  padding: 1rem;
-  font-size: 1.7rem;
-  font-weight: bold;
-  min-height: 7rem;
 `;
 
-const FlexWrapper = styled.div`
-  flex: 1;
-  justify-content: flex-start;
+const Sidebar = styled.div`
+  width: 30rem;
+  background-color: #141c24;
 `;
 
-const ButtonWrapper = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
-  padding: 1rem;
-  font-size: 1.7rem;
-  font-weight: bold;
-  min-height: 7rem;
-`;
-
-const Input = styled.input`
+const SidebarContent = styled.div`
   width: 80%;
-  height: 4rem;
-  border: none;
-  border-radius: 0.6rem;
-  padding: 0.6rem;
+  height: 5rem;
+  margin: 0 auto;
+  color: white;
+
+  font-size: 2rem;
+  font-weight: 900;
+
+  display: flex;
+  align-items: center;
+
+  cursor: pointer;
 `;
 
-const SubmitButton = styled.button`
-  width: 10rem;
-  height: 6rem;
-  background-color: #344051;
-  border: none;
-  border-radius: 0.5rem;
-  color: white;
-  margin: 0 6rem 0 6rem;
-  &:hover {
-    cursor: pointer;
-  }
-  &:disabled {
-    background-color: #d3d3d3;
-    cursor: not-allowed;
-  }
+const MainContent = styled.div`
+  width: calc(100vw - 30rem);
+
+  background-color: #202b37;
+`;
+
+const CloseButtonContainer = styled.div`
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  cursor: pointer;
 `;

--- a/src/components/ModifyChannel/BasicInfoChannel.tsx
+++ b/src/components/ModifyChannel/BasicInfoChannel.tsx
@@ -1,0 +1,134 @@
+import styled from '@emotion/styled';
+import { css } from '@emotion/react';
+import { useRef } from 'react';
+import authAPI from '@apis/authAPI';
+
+interface BasicInfoChannelProps {
+  channelLink: string;
+  leagueTitle: string;
+  maxPlayer: number;
+}
+
+const BasicInfoChannel = ({ channelLink, leagueTitle, maxPlayer }: BasicInfoChannelProps) => {
+  const leagueTitleRef = useRef<HTMLInputElement>(null);
+  const maxPlayerRef = useRef<HTMLInputElement>(null);
+
+  const onClickSubmit = async () => {
+    console.log(leagueTitleRef.current?.value, maxPlayerRef.current?.value);
+    if (!leagueTitleRef.current || !maxPlayerRef.current) return;
+    const updatedLeagueTitle = leagueTitleRef.current.value;
+    const updatedMaxPlayer = parseInt(maxPlayerRef.current.value, 10);
+    if (isNaN(updatedMaxPlayer)) {
+      alert('최대인원수를 숫자로 입력해주세요');
+      return;
+    }
+    if (!confirm('리그를 수정하시겠습니까?')) return;
+    const res = await authAPI({
+      method: 'post',
+      url: `/api/channel/${channelLink}`,
+      data: {
+        title: updatedLeagueTitle,
+        maxPlayer: updatedMaxPlayer,
+      },
+    });
+    if (res.status !== 200) return;
+    alert('정보가 수정되었습니다');
+  };
+
+  return (
+    <Container>
+      <Header>리그 수정하기</Header>
+      <Content>
+        <Wrapper>
+          <FlexWrapper>리그 제목</FlexWrapper>
+          <FlexWrapper>
+            <Input
+              type='text'
+              placeholder='리그 제목을 입력해주세요'
+              ref={leagueTitleRef}
+              defaultValue={leagueTitle}
+            />
+          </FlexWrapper>
+        </Wrapper>
+        <Wrapper>
+          <FlexWrapper>최대 인원</FlexWrapper>
+          <FlexWrapper>
+            <Input
+              type='text'
+              placeholder='최대 인원을 설정해주세요'
+              ref={maxPlayerRef}
+              defaultValue={maxPlayer}
+            />
+          </FlexWrapper>
+        </Wrapper>
+      </Content>
+
+      <ButtonWrapper>
+        <SubmitButton onClick={onClickSubmit}>수정하기</SubmitButton>
+      </ButtonWrapper>
+    </Container>
+  );
+};
+
+export default BasicInfoChannel;
+
+const Container = styled.div`
+  margin: 2rem 4rem;
+`;
+const Header = styled.div`
+  text-align: left;
+
+  font-size: 3rem;
+  font-weight: 900;
+  color: white;
+`;
+
+const Content = styled.div``;
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: 1rem;
+  font-size: 1.7rem;
+  font-weight: bold;
+  min-height: 7rem;
+`;
+
+const FlexWrapper = styled.div`
+  color: white;
+`;
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+
+  font-weight: bold;
+  font-size: 1.8rem;
+`;
+
+const Input = styled.input`
+  width: 80%;
+  height: 4rem;
+  border: none;
+  border-radius: 0.6rem;
+  padding: 0.6rem;
+`;
+
+const SubmitButton = styled.button`
+  width: 10rem;
+  height: 6rem;
+  background-color: #344051;
+  border: none;
+  border-radius: 0.5rem;
+  color: white;
+  margin: 0 6rem 0 6rem;
+  &:hover {
+    cursor: pointer;
+  }
+  &:disabled {
+    background-color: #d3d3d3;
+    cursor: not-allowed;
+  }
+`;

--- a/src/components/ModifyChannel/BracketInfoChannel.tsx
+++ b/src/components/ModifyChannel/BracketInfoChannel.tsx
@@ -1,0 +1,133 @@
+import authAPI from '@apis/authAPI';
+import styled from '@emotion/styled';
+import { useQuery } from '@tanstack/react-query';
+import { MatchCountList } from '@type/channelConfig';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+
+const fetchInitialMatchCount = async (channelLink: string) => {
+  const res = await authAPI<MatchCountList>({
+    method: 'get',
+    url: `/api/match/${channelLink}/count`,
+  });
+  return res.data;
+};
+
+const BracketInfoChannel = () => {
+  const router = useRouter();
+
+  const [roundInfo, setRoundInfo] = useState<number[]>();
+
+  const { data, isLoading, isError, isSuccess } = useQuery({
+    queryKey: ['matchCount', router.query.channelLink as string],
+    queryFn: () => fetchInitialMatchCount(router.query.channelLink as string),
+  });
+
+  const handleRoundInfo = (e: React.ChangeEvent<HTMLSelectElement>, roundIndex: number) => {
+    const changeRoundInfoArr = roundInfo?.map((ele, index) =>
+      index === roundIndex ? Number(e.target.value) : ele,
+    );
+
+    setRoundInfo(changeRoundInfoArr);
+  };
+
+  const updateRoundMatchCount = async () => {
+    try {
+      const res = await authAPI({
+        method: 'post',
+        url: `/api/match/${router.query.channelLink as string}/count`,
+        data: {
+          roundCountList: roundInfo?.reverse(),
+        },
+      });
+
+      console.log(res);
+
+      alert('수정이 완료되었습니다!');
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  useEffect(() => {
+    if (isSuccess) {
+      setRoundInfo(data?.roundCountList.reverse());
+    }
+  }, [data]);
+
+  return (
+    <Container>
+      <Header>라운드 수정</Header>
+      <Content>
+        {roundInfo?.map((currentMatchCount, index) => {
+          return (
+            <RoundInfo key={index}>
+              <RoundInfoHeader>Round {index + 1}</RoundInfoHeader>
+              <select
+                onChange={(e) => handleRoundInfo(e, index)}
+                defaultValue={String(currentMatchCount)}
+              >
+                <option value='1'>1</option>
+                <option value='2'>2</option>
+                <option value='3'>3</option>
+                <option value='4'>4</option>
+                <option value='5'>5</option>
+              </select>
+            </RoundInfo>
+          );
+        })}
+        <ButtonWrapper>
+          <ModifyButton onClick={updateRoundMatchCount}>수정완료</ModifyButton>
+        </ButtonWrapper>
+      </Content>
+    </Container>
+  );
+};
+
+export default BracketInfoChannel;
+
+const Container = styled.div`
+  margin: 2rem 4rem;
+`;
+
+const Header = styled.div`
+  text-align: left;
+
+  font-size: 3rem;
+  font-weight: 900;
+  color: white;
+`;
+
+const Content = styled.div``;
+
+const RoundInfo = styled.div`
+  height: 7rem;
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+`;
+
+const RoundInfoHeader = styled.div`
+  font-size: 2rem;
+  color: white;
+`;
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+`;
+
+const ModifyButton = styled.button`
+  width: 10rem;
+  height: 6rem;
+  background-color: #344051;
+  border: none;
+  border-radius: 0.5rem;
+  color: white;
+  margin: 0 6rem 0 6rem;
+
+  cursor: pointer;
+
+  font-size: 1.8rem;
+`;


### PR DESCRIPTION
## 🤠 개요

- closes: #144 
- 대진이 확정되지 않았을 때 보여줄 화면과 리그 설정 모달 디자인을 변경했어요
- 리그 설정 모달에서 라운드별 매치 횟수를 조정할 수 있어요.


## 💫 설명

- 아래 화면은 아직 대진이 확정되지 않았을 때, 보여주는 화면이에요!
- 처음에 TBD로 보여줄까 생각했지만 64강처럼 인원이 많을 때 전부 TBD로 보여주면 어색할 것 같아 아래와 같이 만들었어요.

<img width="861" alt="33" src="https://github.com/TheUpperPart/leaguehub-frontend/assets/100738049/6472161c-37a3-4dbe-8818-08c47b2c4543">



- 아래 화면은 리그 설정 모달을 전체화면으로 변경하고 기존에 리그 기본 정보만 설정할 수 있었는데 메뉴를 만들어서 리그 기본 정보를 수정하거나 라운드별 매치 횟수를 설정하는 두 개의 메뉴로 구분했어요.

- 아직 디자인이 확정되지 않아 기본 select 태그를 활용했고 디자인이 확정되면 select box를 커스텀할게요!

![녹화_2023_09_16_14_32_45_564](https://github.com/TheUpperPart/leaguehub-frontend/assets/100738049/bd867ee7-4bb4-4bc2-9c83-61fd7736b05d)


