### PR TITLE
Fix: 서버 요청에 유저 인증 토큰값을 넣어 보내기 위해 axios -> authAPI 로 변경

### DIFF
--- a/src/components/Modal/JoinLeague/JoinLeague.tsx
+++ b/src/components/Modal/JoinLeague/JoinLeague.tsx
@@ -4,7 +4,6 @@ import { SERVER_URL } from '@config/index';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import useProfile from '@hooks/useProfile';
-import axios from 'axios';
 import { useState, MouseEventHandler, useEffect, useRef } from 'react';
 
 interface JoinLeagueProps {
@@ -27,7 +26,7 @@ const JoinLeague = ({ onClose, channelLink }: JoinLeagueProps) => {
       return;
     }
     const userTier: string = (
-      await axios.get(SERVER_URL + '/api/participant/stat?gameid=' + gameIdVal)
+      await authAPI.get(SERVER_URL + '/api/participant/stat?gameid=' + gameIdVal)
     ).data.tier;
     setTier(userTier);
     setGameId(gameIdVal);


### PR DESCRIPTION
## 🤠 개요

- closes: #153 
- 서버 요청에 유저 인증 토큰값을 넣어 보내기 위해 axios -> authAPI 로 변경했어요
<!--
- 이슈번호
- 한줄 설명
- closes: #(이슈번호 입력해주세요)
  -->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
