### PR TITLE
Feat/#157: 현재 진행중인 라운드가 채널 보드에 보이도록 추가

### DIFF
--- a/__mocks__/handlers/boardHandlers.ts
+++ b/__mocks__/handlers/boardHandlers.ts
@@ -7,7 +7,11 @@ interface ChannelInfo {
 }
 
 interface BoardsInfo {
-  [key: string]: Channels[];
+  [key: string]: {
+    myMatchRound: number;
+    myMatchId: number;
+    channelBoardLoadDtdList: Channels[];
+  };
 }
 
 const mockChannelInfo: ChannelInfo = {
@@ -38,57 +42,69 @@ const mockChannelInfo: ChannelInfo = {
 };
 
 const boardsInfo: BoardsInfo = {
-  '123': [
-    {
-      boardId: 'aaa',
-      boardTitle: '공지사항',
-      boardIndex: 0,
-    },
-    {
-      boardId: 'bbb',
-      boardTitle: '게임 룰',
-      boardIndex: 1,
-    },
-    {
-      boardId: 'ccc',
-      boardTitle: '커뮤니티',
-      boardIndex: 2,
-    },
-  ],
-  '234': [
-    {
-      boardId: 'bbb',
-      boardTitle: '리그 공지사항',
-      boardIndex: 0,
-    },
-    {
-      boardId: 'ccc',
-      boardTitle: '참여자 규칙',
-      boardIndex: 1,
-    },
-    {
-      boardId: 'ddd',
-      boardTitle: '참여하기',
-      boardIndex: 2,
-    },
-  ],
-  '456': [
-    {
-      boardId: 'eee',
-      boardTitle: '리그 공지사항',
-      boardIndex: 0,
-    },
-    {
-      boardId: 'fff',
-      boardTitle: '참여자 규칙',
-      boardIndex: 1,
-    },
-    {
-      boardId: 'ggg',
-      boardTitle: '참여하기',
-      boardIndex: 2,
-    },
-  ],
+  '123': {
+    myMatchRound: 0,
+    myMatchId: 0,
+    channelBoardLoadDtdList: [
+      {
+        boardId: 'aaa',
+        boardTitle: '공지사항',
+        boardIndex: 0,
+      },
+      {
+        boardId: 'bbb',
+        boardTitle: '게임 룰',
+        boardIndex: 1,
+      },
+      {
+        boardId: 'ccc',
+        boardTitle: '커뮤니티',
+        boardIndex: 2,
+      },
+    ],
+  },
+  '234': {
+    myMatchRound: 1,
+    myMatchId: 1,
+    channelBoardLoadDtdList: [
+      {
+        boardId: 'bbb',
+        boardTitle: '리그 공지사항',
+        boardIndex: 0,
+      },
+      {
+        boardId: 'ccc',
+        boardTitle: '참여자 규칙',
+        boardIndex: 1,
+      },
+      {
+        boardId: 'ddd',
+        boardTitle: '참여하기',
+        boardIndex: 2,
+      },
+    ],
+  },
+  '456': {
+    myMatchRound: 2,
+    myMatchId: 2,
+    channelBoardLoadDtdList: [
+      {
+        boardId: 'eee',
+        boardTitle: '리그 공지사항',
+        boardIndex: 0,
+      },
+      {
+        boardId: 'fff',
+        boardTitle: '참여자 규칙',
+        boardIndex: 1,
+      },
+      {
+        boardId: 'ggg',
+        boardTitle: '참여하기',
+        boardIndex: 2,
+      },
+    ],
+  },
 };
 
 const boardHandlers = [

--- a/src/components/Sidebar/BoardBar/BoardBody.tsx
+++ b/src/components/Sidebar/BoardBar/BoardBody.tsx
@@ -34,6 +34,8 @@ const fetchData = async (channelLink: string) => {
     url: `/api/channel/${channelLink}/boards`,
   });
 
+  console.log(res.data);
+
   return res.data;
 };
 
@@ -132,9 +134,9 @@ const BoardBody = ({ channelLink }: Props) => {
     }
 
     if (isSuccess) {
-      const boards = data.channelBoardLoadDtdList;
-      selectBoardId(boards[0].boardId);
-      handleBoard(channelLink, boards[0].boardId, boards[0].boardTitle);
+      const tmpBoards = data.channelBoardLoadDtdList;
+      selectBoardId(tmpBoards[0].boardId);
+      handleBoard(channelLink, tmpBoards[0].boardId, tmpBoards[0].boardTitle);
     }
   }, [channelLink, isSuccess]);
 


### PR DESCRIPTION
## 🤠 개요

- closes: #157 
- 현재 진행중인 라운드가 채널 보드에 보이도록 추가했어요
- 진행중인 라운드는 자주 변동되기에 lastVisitedBoardIdLists 에 저장하지 않도록했어요

<!--
- 이슈번호
- 한줄 설명
- closes: #(이슈번호 입력해주세요)
  -->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)

https://github.com/TheUpperPart/leaguehub-frontend/assets/71641127/988d4bba-53fd-47b4-93b5-8a9657818944

