### PR TITLE
Feat/#160 관리자 페이지 추가 및 대진표 보드 추가

### DIFF
--- a/__mocks__/browser.ts
+++ b/__mocks__/browser.ts
@@ -9,6 +9,7 @@ import makeGameHandlers from './handlers/makeGameHandlers';
 import mypageHandlers from './handlers/mypageHandlers';
 import bracketHandlers from './handlers/bracketHandlers';
 import matchHandler from '@mocks/handlers/matchHandlers';
+import adminHandlers from './handlers/adminHandlers';
 
 export const worker = setupWorker(
   ...testHandlers,
@@ -20,4 +21,5 @@ export const worker = setupWorker(
   ...mypageHandlers,
   ...bracketHandlers,
   ...matchHandler,
+  ...adminHandlers,
 );

--- a/__mocks__/handlers/adminHandlers.ts
+++ b/__mocks__/handlers/adminHandlers.ts
@@ -1,0 +1,20 @@
+import { SERVER_URL } from '@config/index';
+import { rest } from 'msw';
+
+const adminHandlers = [
+  rest.get(SERVER_URL + '/api/channel/:channelLink/permission', (req, res, ctx) => {
+    const accessToken = req.headers.get('Authorization');
+
+    if (accessToken?.startsWith('Bearer')) {
+      return res(
+        ctx.json({
+          role: 'admin',
+        }),
+      );
+    } else {
+      return res(ctx.status(401), ctx.json({ message: '허용되지 않은 사용자' }));
+    }
+  }),
+];
+
+export default adminHandlers;

--- a/__mocks__/server.ts
+++ b/__mocks__/server.ts
@@ -9,6 +9,7 @@ import makeGameHandlers from './handlers/makeGameHandlers';
 import mypageHandlers from './handlers/mypageHandlers';
 import bracketHandlers from './handlers/bracketHandlers';
 import matchHandler from '@mocks/handlers/matchHandlers';
+import adminHandlers from './handlers/adminHandlers';
 
 export const server = setupServer(
   ...testHandlers,
@@ -20,4 +21,5 @@ export const server = setupServer(
   ...mypageHandlers,
   ...bracketHandlers,
   ...matchHandler,
+  ...adminHandlers,
 );

--- a/src/components/Modal/ModifyChannel/ModifyChannel.tsx
+++ b/src/components/Modal/ModifyChannel/ModifyChannel.tsx
@@ -1,23 +1,33 @@
+import authAPI from '@apis/authAPI';
 import Icon from '@components/Icon';
 import BasicInfoChannel from '@components/ModifyChannel/BasicInfoChannel';
 import BracketInfoChannel from '@components/ModifyChannel/BracketInfoChannel';
 import styled from '@emotion/styled';
+import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
+
 interface ModifyChannelProps {
   channelLink: string;
-  leagueTitle: string;
-  maxPlayer: number;
-  onClose: (leagueTitle?: string, maxPlayer?: number) => void;
+  onClose: () => void;
 }
 
 type MenuList = 'basicInfo' | 'bracketInfo';
 
-const ModifyChannel = ({ channelLink, leagueTitle, maxPlayer, onClose }: ModifyChannelProps) => {
+const fetchChannelInfo = async (channelLink: string) => {
+  const res = await authAPI({ method: 'get', url: `/api/channel/${channelLink}` });
+  return res.data;
+};
+
+const ModifyChannel = ({ channelLink, onClose }: ModifyChannelProps) => {
   const [selectedMenu, setSelectedMenu] = useState<MenuList>('basicInfo');
 
   const handleSelectedMenu = (menu: MenuList) => {
     setSelectedMenu(menu);
   };
+
+  const { data, isSuccess, isError, isLoading } = useQuery(['channelInfo', channelLink], () => {
+    return fetchChannelInfo(channelLink);
+  });
 
   return (
     <Container>
@@ -25,6 +35,7 @@ const ModifyChannel = ({ channelLink, leagueTitle, maxPlayer, onClose }: ModifyC
         <SidebarContent onClick={() => handleSelectedMenu('basicInfo')}>
           대회 기본 정보 수정
         </SidebarContent>
+
         <SidebarContent onClick={() => handleSelectedMenu('bracketInfo')}>
           대진표 수정
         </SidebarContent>
@@ -33,8 +44,8 @@ const ModifyChannel = ({ channelLink, leagueTitle, maxPlayer, onClose }: ModifyC
         {selectedMenu === 'basicInfo' && (
           <BasicInfoChannel
             channelLink={channelLink}
-            leagueTitle={leagueTitle}
-            maxPlayer={maxPlayer}
+            leagueTitle={data?.leagueTitle}
+            maxPlayer={data?.maxPlayer}
           />
         )}
         {selectedMenu === 'bracketInfo' && <BracketInfoChannel />}
@@ -49,11 +60,12 @@ const ModifyChannel = ({ channelLink, leagueTitle, maxPlayer, onClose }: ModifyC
 export default ModifyChannel;
 
 const Container = styled.div`
-  width: 100vw;
-  height: 100vh;
+  width: 80rem;
+  height: 60rem;
   background-color: white;
 
   display: flex;
+  position: relative;
 `;
 
 const Sidebar = styled.div`

--- a/src/components/Sidebar/BoardBar/BoardBody.tsx
+++ b/src/components/Sidebar/BoardBar/BoardBody.tsx
@@ -171,7 +171,27 @@ const BoardBody = ({ channelLink }: Props) => {
                 </div>
               )}
               <div>
-                <Title>공지사항</Title>
+                <Title>보드 목록</Title>
+                {channelPermission === 0 && (
+                  <Wrapper
+                    isSelected={selected === 'admin'}
+                    data-id='admin'
+                    data-board-title='관리자'
+                    onClick={onClickBoard}
+                  >
+                    대회 관리
+                    <Icon kind='lock' color='#637083' size='1.5rem' />
+                  </Wrapper>
+                )}
+                <Wrapper
+                  isSelected={selected === 'bracket'}
+                  data-id='bracket'
+                  data-board-title='대진표'
+                  onClick={onClickBoard}
+                >
+                  대진표
+                  <Icon kind='lock' color='#637083' size='1.5rem' />
+                </Wrapper>
                 {boards &&
                   boards.map((board, index) =>
                     channelPermission === 0 ? (

--- a/src/components/Sidebar/BoardBar/BoardFooter.tsx
+++ b/src/components/Sidebar/BoardBar/BoardFooter.tsx
@@ -1,6 +1,5 @@
 import Modal from '@components/Modal';
 import JoinLeague from '@components/Modal/JoinLeague/JoinLeague';
-import ModifyChannel from '@components/Modal/ModifyChannel/ModifyChannel';
 import styled from '@emotion/styled';
 import useChannels from '@hooks/useChannels';
 import useModals from '@hooks/useModals';
@@ -21,35 +20,8 @@ const BoardFooter = ({
   const { channelPermission } = useChannels();
   const { openModal, closeModal } = useModals();
 
-  const updateChannel = (leagueTitle?: string, maxPlayer?: number) => {
-    if (leagueTitle && maxPlayer) updateChannelData(leagueTitle, maxPlayer);
-
-    closeModal(Modal);
-    return;
-  };
-
   const renderLeagueButton = () => {
     switch (channelPermission) {
-      case 0:
-        return (
-          <div
-            onClick={() =>
-              openModal(Modal, {
-                onClose: () => closeModal(Modal),
-                children: (
-                  <ModifyChannel
-                    channelLink={channelLink}
-                    leagueTitle={leagueTitle}
-                    maxPlayer={maxPlayer}
-                    onClose={updateChannel}
-                  />
-                ),
-              })
-            }
-          >
-            리그 수정하기
-          </div>
-        );
       case 1:
         return <div>리그 나가기</div>;
       case 2:

--- a/src/pages/contents/[channelLink]/admin.tsx
+++ b/src/pages/contents/[channelLink]/admin.tsx
@@ -1,0 +1,117 @@
+import authAPI from '@apis/authAPI';
+import Button from '@components/Button';
+import Modal from '@components/Modal';
+import ModifyChannel from '@components/Modal/ModifyChannel/ModifyChannel';
+import { SERVER_URL } from '@config/index';
+import styled from '@emotion/styled';
+import useModals from '@hooks/useModals';
+import axios from 'axios';
+import { GetServerSideProps } from 'next';
+import { useRouter } from 'next/router';
+
+interface Props {
+  role: string;
+}
+
+const Admin = ({ role }: Props) => {
+  const router = useRouter();
+
+  const { openModal, closeModal } = useModals();
+
+  const fetchNextBracket = async () => {
+    const res = await authAPI({
+      method: 'post',
+      url: `/api/match/${router.query.channelLink as string}/1`,
+    });
+  };
+
+  const fetchStartBracket = async () => {
+    const res = await authAPI({
+      method: 'put',
+      url: `/api/channel/${router.query.channelLink as string}&status=1`,
+    });
+  };
+
+  const handleStartBracket = async () => {
+    if (window.confirm('대회를 시작하시겠습니까?\n대회 시작 후 중지할 수 없습니다!')) {
+      fetchStartBracket();
+    }
+  };
+
+  if (!role) {
+    router.push('/');
+  }
+
+  return (
+    <Container>
+      <Header>대회 매치 설정</Header>
+      <BracketContainer>
+        <Button width={20} height={6} onClick={handleStartBracket}>
+          대회 시작하기
+        </Button>
+
+        <Button width={20} height={6} onClick={fetchNextBracket}>
+          라운드 배정하기
+        </Button>
+      </BracketContainer>
+      <Header>대회 정보 변경</Header>
+      <Button
+        width={20}
+        height={6}
+        onClick={() =>
+          openModal(Modal, {
+            onClose: () => closeModal(Modal),
+            children: (
+              <ModifyChannel
+                channelLink={router.query.channelLink as string}
+                onClose={() => closeModal(Modal)}
+              />
+            ),
+          })
+        }
+      >
+        채널 정보 수정하기
+      </Button>
+    </Container>
+  );
+};
+
+export default Admin;
+
+const Container = styled.div`
+  margin-left: 2rem;
+`;
+
+const Header = styled.div`
+  font-size: 3rem;
+  font-weight: 900;
+  margin: 2rem 0;
+`;
+
+const BracketContainer = styled.div`
+  display: flex;
+  align-items: center;
+  column-gap: 3rem;
+`;
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  try {
+    const res = await axios({
+      method: 'get',
+      url: SERVER_URL + `/api/channel/${context.query.channelLink as string}/permission`,
+    });
+
+    return {
+      props: {
+        role: 'admin',
+      },
+    };
+  } catch (error) {
+    return {
+      redirect: {
+        permanent: false,
+        destination: '/',
+      },
+    };
+  }
+};


### PR DESCRIPTION
## 🤠 개요

- closes: #160 
- 관리자 페이지의 틀을 만들었어요.
- 대진표 보드도 보드 목록에 추가했어요.



## 💫 설명
아직 모든 기능이 작동하진 않지만 관리자 페이지를 만들었어요. 그리고 하단에 표시되던 리그 수정을 없애고 대회 관리라는 보드를 보드 목록 최상단에 추가했어요. 해당 보드는 관리자만 볼 수 있어요
또, 대진표 채널도 대회 관리 하단에 추가했어요.

## 📷 스크린샷 (Optional)

<img width="1158" alt="2" src="https://github.com/TheUpperPart/leaguehub-frontend/assets/100738049/4ed872e4-cb26-4d57-b085-c5f53e616081">
