### PR TITLE
Feat/#165: 게임 결과 입력하는 칸 추가 및 자동으로 다음 라운드 페이지가 보이도록 추가

### DIFF
--- a/__mocks__/handlers/matchHandlers.ts
+++ b/__mocks__/handlers/matchHandlers.ts
@@ -6,7 +6,7 @@ const players: GetMatchPlayerScoreInfos = {
   requestMatchPlayerId: 3,
   currentMatchRound: 1,
   totalMatchRound: 3,
-  matchPlayerScoreInfos: [
+  matchPlayerInfos: [
     {
       matchPlayerId: 1,
       participantId: 1,

--- a/__mocks__/handlers/matchHandlers.ts
+++ b/__mocks__/handlers/matchHandlers.ts
@@ -4,8 +4,9 @@ import { rest } from 'msw';
 
 const players: GetMatchPlayerScoreInfos = {
   requestMatchPlayerId: 3,
-  currentMatchRound: 1,
-  totalMatchRound: 3,
+  matchRound: 1,
+  matchCurrentSet: 1,
+  matchSetCount: 3,
   matchPlayerInfos: [
     {
       matchPlayerId: 1,

--- a/src/components/RoundCheckIn/CallAdminChat.tsx
+++ b/src/components/RoundCheckIn/CallAdminChat.tsx
@@ -44,7 +44,7 @@ const CallAdminChat = ({
     )?.participantId;
 
     const newMessage = {
-      channelId: channelLink,
+      channelLink,
       content: inputMessage,
       matchId,
       participantId: requestUserParticipantId,
@@ -68,6 +68,12 @@ const CallAdminChat = ({
     const user = players.find((player) => player.participantId === playerParticipantId);
     if (!user) return '';
     return user.gameId;
+  };
+
+  const findRequestUser = (playerParticipantId: number): number => {
+    const user = players.find((player) => player.participantId === playerParticipantId);
+    if (!user) return -1;
+    return user.matchPlayerId;
   };
 
   useEffect(() => {
@@ -97,18 +103,26 @@ const CallAdminChat = ({
           chats.map((message, idx) => (
             <ChattingInfo key={idx}>
               <ChattingContent>
-                <ImageWrapper>
-                  <Image
-                    src={findUserIMG(message.participantId)}
-                    alt='프로필사진'
-                    width={45}
-                    height={45}
-                  />
-                </ImageWrapper>
-                <ContentWrapper>
-                  <ContentName>{findUserName(message.participantId)}</ContentName>
-                  <ContentText>{message.content}</ContentText>
-                </ContentWrapper>
+                {requestUser === findRequestUser(message.participantId) ? (
+                  <MyChattingContent>
+                    <MyContentText>{message.content}</MyContentText>
+                  </MyChattingContent>
+                ) : (
+                  <>
+                    <ImageWrapper>
+                      <Image
+                        src={findUserIMG(message.participantId)}
+                        alt='프로필사진'
+                        width={45}
+                        height={45}
+                      />
+                    </ImageWrapper>
+                    <ContentWrapper>
+                      <ContentName>{findUserName(message.participantId)}</ContentName>
+                      <ContentText>{message.content}</ContentText>
+                    </ContentWrapper>
+                  </>
+                )}
               </ChattingContent>
             </ChattingInfo>
           ))}
@@ -169,6 +183,7 @@ const ImageWrapper = styled.div`
 
 const ContentWrapper = styled.div`
   margin-left: 0.5rem;
+  max-width: 70%;
 `;
 
 const ContentName = styled.div`
@@ -184,6 +199,17 @@ const ContentText = styled.div`
   font-size: 1.3rem;
 `;
 
+const MyContentText = styled.div`
+  padding: 0.5rem;
+  border: 1px solid black;
+  background: yellow;
+  border-radius: 1rem 0 1rem 1rem;
+  display: flex;
+  align-items: center;
+  font-size: 1.3rem;
+  margin-right: 1rem;
+`;
+
 const ChattingInfo = styled.div`
   min-height: 5rem;
   display: flex;
@@ -193,6 +219,13 @@ const ChattingInfo = styled.div`
 
 const ChattingContent = styled.div`
   display: flex;
+  width: 100%;
+`;
+
+const MyChattingContent = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
 `;
 
 const InputChat = styled.input`

--- a/src/components/RoundCheckIn/CheckInPage.tsx
+++ b/src/components/RoundCheckIn/CheckInPage.tsx
@@ -57,9 +57,12 @@ const CheckInPage = ({
   };
 
   useEffect(() => {
-    if (ready) return;
     const findUser = checkInUser.find((user) => requestUser === user);
-    if (findUser === undefined) return;
+    if (findUser === undefined) {
+      setReady(false);
+      return;
+    }
+
     setReady(true);
   }, [checkInUser]);
 
@@ -71,12 +74,14 @@ const CheckInPage = ({
         <RemainTimeItem></RemainTimeItem>
       </RemainTimeWrapper>
       <ButtonWrapper>
-        {players.length !== 0 && players.length === checkInUser.length ? (
+        {players.length !== 0 && players.length <= checkInUser.length ? (
           <>
             <RankingSelect value={rank} onChange={handleRankingChange} disabled={isSendingRanking}>
               <option value=''>경기 후 게임 결과를 입력해주세요</option>
               {players.map((player, idx) => (
-                <option value={idx + 1}>{idx + 1}등</option>
+                <option key={idx} value={idx + 1}>
+                  {idx + 1}등
+                </option>
               ))}
             </RankingSelect>
             <RankingSubmitButton disabled={isSendingRanking} onClick={onClickRankingButton}>

--- a/src/components/RoundCheckIn/CheckInPage.tsx
+++ b/src/components/RoundCheckIn/CheckInPage.tsx
@@ -73,7 +73,7 @@ const CheckInPage = ({
       <ButtonWrapper>
         {players.length !== 0 && players.length === checkInUser.length ? (
           <>
-            <RankingSelect value={rank} onChange={handleRankingChange}>
+            <RankingSelect value={rank} onChange={handleRankingChange} disabled={isSendingRanking}>
               <option value=''>경기 후 게임 결과를 입력해주세요</option>
               {players.map((player, idx) => (
                 <option value={idx + 1}>{idx + 1}등</option>
@@ -157,7 +157,7 @@ const ChattingWrapper = styled.div``;
 
 const RankingSelect = styled.select`
   height: 5rem;
-  width: 70%;
+  width: ${(props) => (props.disabled ? '100%' : '70%')};
 `;
 
 const RankingSubmitButton = styled.button`
@@ -167,6 +167,7 @@ const RankingSubmitButton = styled.button`
   background: #637083;
   border: none;
   border-radius: 0.5rem;
+  display: ${(props) => (props.disabled ? 'none' : 'block')};
 
   &: hover {
     cursor: pointer;

--- a/src/components/RoundCheckIn/CheckInPage.tsx
+++ b/src/components/RoundCheckIn/CheckInPage.tsx
@@ -3,6 +3,7 @@ import { MatchMessages, MatchPlayerScoreInfos } from '@components/RoundCheckIn';
 import CallAdminChat from '@components/RoundCheckIn/CallAdminChat';
 import styled from '@emotion/styled';
 import { Client } from '@stomp/stompjs';
+import { ChangeEventHandler, MouseEventHandler, useEffect, useState } from 'react';
 
 interface CheckInPageProps {
   ParticipantCheckin: () => void;
@@ -11,6 +12,8 @@ interface CheckInPageProps {
   players: MatchPlayerScoreInfos[];
   matchMessage: MatchMessages[];
   requestUser: number;
+  checkInUser: number[];
+  currentMatchRound: number;
 }
 
 const CheckInPage = ({
@@ -20,18 +23,78 @@ const CheckInPage = ({
   players,
   matchMessage,
   requestUser,
+  checkInUser,
+  currentMatchRound,
 }: CheckInPageProps) => {
+  const [ready, setReady] = useState<boolean>(false);
+  const [isSendingRanking, setIsSendingRanking] = useState<boolean>(false);
+  const [rank, setRank] = useState<string>('');
+
+  const handleRankingChange: ChangeEventHandler<HTMLSelectElement> = (e) => {
+    if (!e.target) return;
+    setRank(e.target.value);
+  };
+
+  const onClickRankingButton: MouseEventHandler<HTMLElement> = () => {
+    if (rank === '') {
+      alert('결과를 입력해주세요');
+      return;
+    }
+
+    if (!confirm(`게임 결과 ${rank}등이 맞나요?`)) return;
+
+    if (rank === '1' || rank === '2') {
+      if (!client || currentMatchRound === -1) {
+        alert('서버에 에러가 발생했습니다. 새로고침 후 입력 부탁드립니다');
+        return;
+      }
+
+      client.publish({
+        destination: `/app/match/${matchId}/${currentMatchRound}/score-update`,
+      });
+    }
+    setIsSendingRanking(true);
+  };
+
+  useEffect(() => {
+    if (ready) return;
+    const findUser = checkInUser.find((user) => requestUser === user);
+    if (findUser === undefined) return;
+    setReady(true);
+  }, [checkInUser]);
+
   return (
     <Container>
       <RemainTimeWrapper>
         <Icon kind='clock' />
         <RemainTimeItem>남은시간</RemainTimeItem>
-        <RemainTimeItem>04:59</RemainTimeItem>
+        <RemainTimeItem></RemainTimeItem>
       </RemainTimeWrapper>
       <ButtonWrapper>
-        <Button onClick={() => ParticipantCheckin()}>준비</Button>
-        <Button>기권</Button>
+        {players.length !== 0 && players.length === checkInUser.length ? (
+          <>
+            <RankingSelect value={rank} onChange={handleRankingChange}>
+              <option value=''>경기 후 게임 결과를 입력해주세요</option>
+              {players.map((player, idx) => (
+                <option value={idx + 1}>{idx + 1}등</option>
+              ))}
+            </RankingSelect>
+            <RankingSubmitButton disabled={isSendingRanking} onClick={onClickRankingButton}>
+              전송
+            </RankingSubmitButton>
+          </>
+        ) : (
+          <>
+            <Button disabled={ready} onClick={() => ParticipantCheckin()}>
+              준비
+            </Button>
+            <Button disabled={ready} onClick={() => alert('해당 경기는 기권이 불가능합니다')}>
+              기권
+            </Button>
+          </>
+        )}
       </ButtonWrapper>
+
       <ChattingWrapper>
         <CallAdminChat
           client={client}
@@ -81,6 +144,7 @@ const Button = styled.button`
   height: 5rem;
   color: white;
   background: #637083;
+  background: ${(props) => (props.disabled ? '#ced4da' : '#637083')};
   border: none;
   border-radius: 0.5rem;
 
@@ -90,3 +154,21 @@ const Button = styled.button`
 `;
 
 const ChattingWrapper = styled.div``;
+
+const RankingSelect = styled.select`
+  height: 5rem;
+  width: 70%;
+`;
+
+const RankingSubmitButton = styled.button`
+  width: 26%;
+  height: 5rem;
+  color: white;
+  background: #637083;
+  border: none;
+  border-radius: 0.5rem;
+
+  &: hover {
+    cursor: pointer;
+  }
+`;

--- a/src/components/RoundCheckIn/index.tsx
+++ b/src/components/RoundCheckIn/index.tsx
@@ -77,7 +77,9 @@ const RoundCheckIn = ({ channelLink, matchId }: RoundCheckInProps) => {
     tmpClient.onConnect = () => {
       setClient(tmpClient);
       subscription = tmpClient.subscribe(`/match/${matchId}`, (data) => {
-        setCheckInUser((prevUsers) => [...prevUsers, Number(JSON.parse(data.body).matchPlayerId)]);
+        const readyUserPlayerId = Number(JSON.parse(data.body).matchPlayerId);
+        if (checkInUser.includes(readyUserPlayerId)) return;
+        setCheckInUser((prevUsers) => [...prevUsers, readyUserPlayerId]);
       });
     };
 
@@ -128,6 +130,8 @@ const RoundCheckIn = ({ channelLink, matchId }: RoundCheckInProps) => {
           players={matchPlayers ? matchPlayers.matchPlayerInfos : []}
           matchMessage={matchPlayers ? matchPlayers.matchMessage : []}
           requestUser={matchPlayers ? matchPlayers.requestMatchPlayerId : -1}
+          checkInUser={checkInUser}
+          currentMatchRound={matchPlayers ? matchPlayers.currentMatchRound : -1}
         />
       </FlexWrapper>
     </Container>


### PR DESCRIPTION
## 🤠 개요

- closes: #165 
- 모두 준비가 완료되면 준비버튼에서 게임 결과를 입력하는 박스가 생성되도록 추가했어요
- 결과를 한번 입력하면 새로고침 할 때까지 결과를 입력하지 못하게 막아뒀어요
- 1등 또는 2등이 입력되면 다음 라운드의 체크인페이지가 보이도록 추가했어요
<!--
- 이슈번호
- 한줄 설명
- closes: #(이슈번호 입력해주세요)
  -->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
https://github.com/TheUpperPart/leaguehub-frontend/assets/71641127/7101c849-c2aa-4523-a76e-a64fca0836d4

