### PR TITLE
Feat/#167 관리자 페이지 기능 추가

### DIFF
--- a/src/@types/bracket.ts
+++ b/src/@types/bracket.ts
@@ -12,12 +12,12 @@ interface PlayerInfo {
 }
 interface MatchInfo {
   matchName: string;
-  matchLink: string;
   matchStatus: string;
   matchRound: number;
-  matchRoundCount: number;
-  matchRoundMaxCount: number;
+  matchCurrentSet: number;
+  matchSetCurrent: number;
   matchPlayerInfoList: PlayerInfo[];
+  matchId: number;
 }
 
 export interface BracketContents {

--- a/src/components/Bracket/BracketContents.tsx
+++ b/src/components/Bracket/BracketContents.tsx
@@ -31,6 +31,10 @@ const BracketContents = (props: Props) => {
     },
   );
 
+  const moveToCheckIn = (matchId: number) => {
+    router.push(`/contents/${router.query.channelLink as string}/checkIn/${matchId}`);
+  };
+
   return (
     <Container>
       <Header></Header>
@@ -39,9 +43,11 @@ const BracketContents = (props: Props) => {
           return (
             <MatchContainer>
               <MatchHeader>
-                <MatchHeaderRound>M{match.matchRoundCount}</MatchHeaderRound>
+                <MatchHeaderRound>M{match.matchCurrentSet}</MatchHeaderRound>
                 <MatchHeaderName>{match.matchName}</MatchHeaderName>
-                <MatchHeaderMore>자세히</MatchHeaderMore>
+                <MatchHeaderMore onClick={() => moveToCheckIn(match.matchId)}>
+                  자세히
+                </MatchHeaderMore>
               </MatchHeader>
               <MatchContent>
                 {match.matchPlayerInfoList.length === 0 ? (
@@ -161,6 +167,8 @@ const MatchHeaderMore = styled.div`
   color: #ffffff;
   font-weight: 7000;
   font-size: 1.2rem;
+
+  cursor: pointer;
 `;
 
 const MatchContent = styled.div`

--- a/src/components/Modal/ModifyChannel/ModifyBracket.tsx
+++ b/src/components/Modal/ModifyChannel/ModifyBracket.tsx
@@ -1,0 +1,95 @@
+import { useState } from 'react';
+import styled from '@emotion/styled';
+
+import Icon from '@components/Icon';
+import StartMatch from '@components/ModifyChannel/StartMatch';
+import AssignBracket from '@components/ModifyChannel/AssignBracket';
+
+interface Props {
+  onClose: () => void;
+}
+
+const ModifyBracket = ({ onClose }: Props) => {
+  const [selectedMenu, setSelectedMenu] = useState<'match' | 'bracket'>('match');
+
+  return (
+    <Container>
+      <Content>
+        <Header>
+          <HeaderList
+            isSelected={selectedMenu === 'match'}
+            onClick={() => setSelectedMenu('match')}
+          >
+            대회 시작
+          </HeaderList>
+          <HeaderList
+            isSelected={selectedMenu === 'bracket'}
+            onClick={() => setSelectedMenu('bracket')}
+          >
+            경기 배정
+          </HeaderList>
+        </Header>
+        {selectedMenu === 'match' && <StartMatch />}
+        {selectedMenu === 'bracket' && <AssignBracket />}
+        <CloseButtonContainer>
+          <Icon kind='cancel' size={40} onClick={() => onClose()} />
+        </CloseButtonContainer>
+      </Content>
+    </Container>
+  );
+};
+
+export default ModifyBracket;
+
+const Container = styled.div`
+  position: relative;
+
+  width: 40rem;
+  height: 60rem;
+  display: flex;
+
+  background-color: #344051;
+`;
+
+const Content = styled.div`
+  margin: 2rem 1rem;
+`;
+
+const Header = styled.div`
+  color: white;
+
+  font-size: 2rem;
+
+  height: 5rem;
+
+  display: flex;
+  align-items: center;
+  column-gap: 2rem;
+`;
+
+const HeaderList = styled.button<{ isSelected: boolean }>`
+  margin: 0;
+  padding: 0;
+  border: none;
+
+  ${(prop) =>
+    prop.isSelected &&
+    `
+      text-decoration:underline;
+      text-underline-position: under;
+    `}
+
+  background-color: inherit;
+  color: white;
+  font-size: 2rem;
+  font-weight: 900;
+
+  cursor: pointer;
+`;
+
+const CloseButtonContainer = styled.div`
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  cursor: pointer;
+`;

--- a/src/components/ModifyChannel/AssignBracket.tsx
+++ b/src/components/ModifyChannel/AssignBracket.tsx
@@ -1,0 +1,118 @@
+import authAPI from '@apis/authAPI';
+import styled from '@emotion/styled';
+import { useQuery } from '@tanstack/react-query';
+import { BracketHeader } from '@type/bracket';
+import { AxiosError } from 'axios';
+import { useRouter } from 'next/router';
+
+type bracketStatus = 'DONE' | 'READY' | 'BAN';
+
+const fetchAllBracket = async (channelLink: string) => {
+  const res = await authAPI<BracketHeader>({
+    method: 'get',
+    url: `/api/match/${channelLink}`,
+  });
+
+  console.log(res);
+
+  return res.data;
+};
+
+const AssignBracket = () => {
+  const router = useRouter();
+
+  const { data, isSuccess } = useQuery<BracketHeader>(['bracketSetting'], () => {
+    return fetchAllBracket(router.query.channelLink as string);
+  });
+
+  const fetchSetBracket = async (round: number) => {
+    if (window.confirm(`Round ${round}를 배정하시겠습니까?`)) {
+      try {
+        const res = await authAPI({
+          method: 'post',
+          url: `/api/match/${router.query.channelLink as string}/${round}`,
+        });
+
+        if (isSuccess) {
+          data.liveRound = round;
+        }
+      } catch (error) {
+        if (error instanceof AxiosError) {
+          window.alert(error.response?.data.message);
+        }
+      }
+    }
+  };
+
+  return (
+    <Container>
+      {data?.roundList.map((round) => {
+        return (
+          <Bracket>
+            <BracketHeader>Round {round}</BracketHeader>
+            {round === data.liveRound && <BracketButton status='DONE'>배정 완료</BracketButton>}
+            {round === data.liveRound + 1 && (
+              <BracketButton status='READY' onClick={() => fetchSetBracket(round)}>
+                배정하기
+              </BracketButton>
+            )}
+            {round > data.liveRound + 1 && <BracketButton status='BAN'>배정 불가</BracketButton>}
+          </Bracket>
+        );
+      })}
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  margin: 2rem 1rem;
+`;
+
+const Bracket = styled.div`
+  display: flex;
+  align-items: center;
+
+  column-gap: 2rem;
+
+  margin: 2rem 0;
+`;
+
+const BracketHeader = styled.div`
+  font-size: 1.6rem;
+
+  color: white;
+`;
+
+const BracketButton = styled.button<{ status: bracketStatus }>`
+  width: 12rem;
+  height: 4rem;
+  border: none;
+  padding: 0;
+  margin: 0;
+
+  font-size: 1.6rem;
+  color: white;
+
+  ${(prop) =>
+    prop.status === 'DONE' &&
+    `
+    background-color : #7C81AD;
+    cursor: not-allowed;
+  `}
+
+  ${(prop) =>
+    prop.status === 'READY' &&
+    `
+    background-color : #1AACAC;
+    cursor: pointer;
+  `}
+
+  ${(prop) =>
+    prop.status === 'BAN' &&
+    `
+    background-color : #FF6969;
+    cursor: not-allowed
+  `}
+`;
+
+export default AssignBracket;

--- a/src/components/ModifyChannel/StartMatch.tsx
+++ b/src/components/ModifyChannel/StartMatch.tsx
@@ -1,0 +1,45 @@
+import authAPI from '@apis/authAPI';
+import Button from '@components/Button';
+import styled from '@emotion/styled';
+import { AxiosError } from 'axios';
+import { useRouter } from 'next/router';
+
+const StartMatch = () => {
+  const router = useRouter();
+
+  const fetchStartBracket = async () => {
+    const res = await authAPI({
+      method: 'put',
+      url: `/api/channel/${router.query.channelLink as string}?status=1`,
+    });
+
+    return res;
+  };
+
+  const handleStartMatch = async () => {
+    if (window.confirm('대회를 시작하시겠습니까?\n시작한 이후에는 중지할 수 없습니다')) {
+      try {
+        const res = fetchStartBracket();
+        window.alert('대회가 시작되었습니다!\nRound 1 배정을 해주세요!');
+      } catch (error) {
+        if (error instanceof AxiosError) {
+          window.alert(error.response?.data.message);
+        }
+      }
+    }
+  };
+
+  return (
+    <Container>
+      <Button width={20} height={5} onClick={handleStartMatch}>
+        대회 시작
+      </Button>
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  margin: 2rem 1rem;
+`;
+
+export default StartMatch;

--- a/src/pages/contents/[channelLink]/admin.tsx
+++ b/src/pages/contents/[channelLink]/admin.tsx
@@ -1,14 +1,17 @@
-import authAPI from '@apis/authAPI';
-import Button from '@components/Button';
-import Modal from '@components/Modal';
-import ModifyChannel from '@components/Modal/ModifyChannel/ModifyChannel';
-import { SERVER_URL } from '@config/index';
-import styled from '@emotion/styled';
-import useModals from '@hooks/useModals';
 import axios from 'axios';
-import { GetServerSideProps } from 'next';
+import styled from '@emotion/styled';
 import { useRouter } from 'next/router';
+import { GetServerSideProps } from 'next';
 
+import Modal from '@components/Modal';
+import Button from '@components/Button';
+import ModifyBracket from '@components/Modal/ModifyChannel/ModifyBracket';
+import ModifyChannel from '@components/Modal/ModifyChannel/ModifyChannel';
+
+import useModals from '@hooks/useModals';
+
+import { SERVER_URL } from '@config/index';
+import { parse } from 'cookie';
 interface Props {
   role: string;
 }
@@ -18,43 +21,28 @@ const Admin = ({ role }: Props) => {
 
   const { openModal, closeModal } = useModals();
 
-  const fetchNextBracket = async () => {
-    const res = await authAPI({
-      method: 'post',
-      url: `/api/match/${router.query.channelLink as string}/1`,
-    });
-  };
-
-  const fetchStartBracket = async () => {
-    const res = await authAPI({
-      method: 'put',
-      url: `/api/channel/${router.query.channelLink as string}&status=1`,
-    });
-  };
-
-  const handleStartBracket = async () => {
-    if (window.confirm('대회를 시작하시겠습니까?\n대회 시작 후 중지할 수 없습니다!')) {
-      fetchStartBracket();
-    }
-  };
-
   if (!role) {
     router.push('/');
   }
 
   return (
     <Container>
-      <Header>대회 매치 설정</Header>
+      <Header>대회 설정</Header>
       <BracketContainer>
-        <Button width={20} height={6} onClick={handleStartBracket}>
-          대회 시작하기
-        </Button>
-
-        <Button width={20} height={6} onClick={fetchNextBracket}>
-          라운드 배정하기
+        <Button
+          width={20}
+          height={6}
+          onClick={() =>
+            openModal(Modal, {
+              onClose: () => closeModal(Modal),
+              children: <ModifyBracket onClose={() => closeModal(Modal)} />,
+            })
+          }
+        >
+          대회 관리하기
         </Button>
       </BracketContainer>
-      <Header>대회 정보 변경</Header>
+      <Header>채널 정보 설정</Header>
       <Button
         width={20}
         height={6}
@@ -96,9 +84,15 @@ const BracketContainer = styled.div`
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   try {
+    const cookies = parse(context.req.headers.cookie || 'no-cookie');
+    const accessToken = cookies.accessToken || undefined;
+
     const res = await axios({
       method: 'get',
       url: SERVER_URL + `/api/channel/${context.query.channelLink as string}/permission`,
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
     });
 
     return {


### PR DESCRIPTION
## 🤠 개요

- closes: #167 
- 관리자 페이지에 기능을 추가했어요.

## 💫 설명
#160 해당 이슈에 이어서 관리자 페이지 기능을 추가했어요. getServerSideProps로 우선 관리자 권한인지 확인해요. 관리자라면 관리자 페이지를 보여주고 아니라면 메인 화면으로 이동시켜요.

두 번째로 대회 시작 기능을 추가했어요. 대회를 시작한 후에 라운드 참가자 배정을 할 수 있어요.
마지막으로, 라운드 참가자 배정을 추가했어요. 최초에 전체 라운드와 liveRound를 가져와서 이미 배정 완료된 라운드와 배정 가능한 라운드 배정 불가능한 라운드 이렇게 구분해요.

## 📷 스크린샷 (Optional)

https://github.com/TheUpperPart/leaguehub-frontend/assets/100738049/142e38a6-2e6c-4b4a-9438-55957b2df535

