### PR TITLE
Fix/#176: 채널 보드에서 발생하는 문제 해결

### DIFF
--- a/src/components/Sidebar/BoardBar/BoardBody.tsx
+++ b/src/components/Sidebar/BoardBar/BoardBody.tsx
@@ -140,6 +140,17 @@ const BoardBody = ({ channelLink }: Props) => {
     }
   }, [channelLink, isSuccess]);
 
+  useEffect(() => {
+    setBoards((prevBoards) => {
+      return prevBoards.map((board) => {
+        if (board.boardId === selected) {
+          return { ...board, boardTitle: lastVisitedBoardIdLists[channelLink].boardTitle };
+        }
+        return board;
+      });
+    });
+  }, [lastVisitedBoardIdLists[channelLink]?.boardTitle]);
+
   return (
     <Container>
       <DragDropContext onDragEnd={dragEnd}>

--- a/src/components/Sidebar/BoardBar/BoardBody.tsx
+++ b/src/components/Sidebar/BoardBar/BoardBody.tsx
@@ -162,10 +162,10 @@ const BoardBody = ({ channelLink }: Props) => {
                   <Title>현재 라운드</Title>
                   <Wrapper
                     onClick={() => {
-                      setSelected('bracket');
+                      setSelected('CurrentRound');
                       router.push(`/contents/${channelLink}/checkIn/${data.myMatchId}`);
                     }}
-                    isSelected={selected === 'bracket'}
+                    isSelected={selected === 'CurrentRound'}
                   >
                     <CurrentRound>
                       <div>라운드 {data.myMatchRound}</div>

--- a/src/components/providers/LastVisitedBoardListsProvider.tsx
+++ b/src/components/providers/LastVisitedBoardListsProvider.tsx
@@ -1,10 +1,13 @@
 import LastVisitedBoardListsContext from '@contexts/LastVisitedBoardListsContext';
 import { useState } from 'react';
 
+interface LastVisitedBoard {
+  boardId: string;
+  boardTitle: string;
+}
+
 export interface LastVisitedBoardList {
-  [key: string]: {
-    [boardId: string]: string;
-  };
+  [key: string]: LastVisitedBoard;
 }
 
 interface Props {


### PR DESCRIPTION
## 🤠 개요

- closes: #176 
- 관리자가 채널 제목을 변경하면 채널 보드 바디에서도 변경된 채널 제목이 적용되도록 수정
- 체크인 페이지와 대진표 페이지가 동일한 보드 ID 값을 가져 같이 선택되는듯한 문제 해결
<!--
- 이슈번호
- 한줄 설명
- closes: #(이슈번호 입력해주세요)
  -->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)

https://github.com/TheUpperPart/leaguehub-frontend/assets/71641127/1b2dfa9e-f42f-415c-8db2-c86eaf1d1429

