### PR TITLE
Fix: 새로고침 시 채널 보드 바가 보이지 않는 문제 해결

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -1,5 +1,4 @@
 import { PropsWithChildren, useEffect, useState } from 'react';
-import { useRouter } from 'next/router';
 import styled from '@emotion/styled';
 
 import ChannelBar from '@components/Sidebar/ChannelBar/ChannelBar';
@@ -9,8 +8,6 @@ import Header from '@components/Header/Header';
 import useChannels from '@hooks/useChannels';
 
 const Layout = ({ children }: PropsWithChildren) => {
-  const router = useRouter();
-
   const { channels } = useChannels();
   const [selectedChannelLink, setSelectedChannelLink] = useState<string | null>(null);
 
@@ -20,7 +17,7 @@ const Layout = ({ children }: PropsWithChildren) => {
 
   useEffect(() => {
     // 새로고침시 첫 번째 채널 보여주도록 설정
-    if (channels && router.asPath === '/') {
+    if (channels) {
       channels.length !== 0 && setSelectedChannelLink(channels[0].channelLink);
     }
   }, [channels]);


### PR DESCRIPTION
## 🤠 개요

- closes: #188 
- 새로고침 시 채널 보드 바가 보이지 않는 문제 해결했어요
- 문제 원인은 pathname 이 '/' 인 경우에만 채널 보드가 보이도록 되어있어서 안됐었어요!
<!--
- 이슈번호
- 한줄 설명
- closes: #(이슈번호 입력해주세요)
  -->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
