### PR TITLE
Fix/#192: 플레이어 리스트에서 게임 아이디를 한 줄로 표시하도록 수정

### DIFF
--- a/src/components/RoundCheckIn/PlayerLists.tsx
+++ b/src/components/RoundCheckIn/PlayerLists.tsx
@@ -16,6 +16,10 @@ interface CheckMine {
   isDisqualification: boolean;
 }
 
+interface FlexVal {
+  flexVal: number;
+}
+
 const PlayerLists = ({ players, checkInUsers, requestUser }: PlayerListsProps) => {
   const router = useRouter();
   const { channelLink } = router.query;
@@ -48,10 +52,10 @@ const PlayerLists = ({ players, checkInUsers, requestUser }: PlayerListsProps) =
             width: 7rem;
           `}
         ></div>
-        <MenuItem>순위</MenuItem>
-        <MenuItem>게임ID</MenuItem>
-        <MenuItem>점수</MenuItem>
-        <MenuItem>준비</MenuItem>
+        <MenuItem flexVal={1}>순위</MenuItem>
+        <MenuItem flexVal={3}>게임ID</MenuItem>
+        <MenuItem flexVal={1}>점수</MenuItem>
+        <MenuItem flexVal={1}>준비</MenuItem>
       </MenuList>
       {players.length !== 0 &&
         players.map((player) => (
@@ -71,10 +75,10 @@ const PlayerLists = ({ players, checkInUsers, requestUser }: PlayerListsProps) =
                 `}
               ></div>
             )}
-            <MenuItem># {player.matchRank}</MenuItem>
-            <MenuItem>{player.gameId}</MenuItem>
-            <MenuItem>{player.score}</MenuItem>
-            <MenuItem>
+            <MenuItem flexVal={1}># {player.matchRank}</MenuItem>
+            <MenuItem flexVal={3}>{player.gameId}</MenuItem>
+            <MenuItem flexVal={1}>{player.score}</MenuItem>
+            <MenuItem flexVal={1}>
               {checkInUsers.includes(player.matchPlayerId) ? (
                 <Icon kind='checked' color='1975FF' size={24} />
               ) : player.playerStatus === 'DISQUALIFICATION' ? (
@@ -119,12 +123,13 @@ const MenuList = styled.ul<CheckMine>`
   }
 `;
 
-const MenuItem = styled.li`
+const MenuItem = styled.li<FlexVal>`
   width: 5rem;
   text-align: center;
   align-items: center;
   justify-content: center;
   margin: 0 auto;
+  flex: ${(props) => props.flexVal};
 `;
 
 const DisqualificationButton = styled.button`

--- a/src/components/RoundCheckIn/PlayerLists.tsx
+++ b/src/components/RoundCheckIn/PlayerLists.tsx
@@ -130,6 +130,15 @@ const MenuItem = styled.li<FlexVal>`
   justify-content: center;
   margin: 0 auto;
   flex: ${(props) => props.flexVal};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  &: hover {
+    white-space: normal;
+    overflow: visible;
+    text-overflow: unset;
+  }
 `;
 
 const DisqualificationButton = styled.button`


### PR DESCRIPTION
## 🤠 개요

- closes: #192 
- 게임아이디가 너무 긴 경우 ... 으로 표시하도록 수정했어요
- 만약 hover 하면 게임아이디 풀네임이 보이도록 했어요
<!--
- 이슈번호
- 한줄 설명
- closes: #(이슈번호 입력해주세요)
  -->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
