### PR TITLE
Fix/#206 msw 실행 시점 변경

### DIFF
--- a/src/components/MSWComponent/MSWComponent.tsx
+++ b/src/components/MSWComponent/MSWComponent.tsx
@@ -1,0 +1,29 @@
+import initMockAPI from '@mocks/index';
+import { useEffect, useState } from 'react';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+const MSWComponent = ({ children }: Props) => {
+  const [mswStateIsReady, setMswStateIsReady] = useState<boolean>(false);
+
+  useEffect(() => {
+    const initMSW = async () => {
+      await initMockAPI();
+      setMswStateIsReady(true);
+    };
+
+    if (!mswStateIsReady) {
+      initMSW();
+    }
+  }, []);
+
+  if (!mswStateIsReady) {
+    return <>MSW Loading....</>;
+  }
+
+  return <>{children}</>;
+};
+
+export default MSWComponent;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -8,13 +8,11 @@ import ProfileProvider from '@components/providers/ProfileProvider';
 import MakeGameProvider from '@components/providers/MakeGameProvider';
 import ChannelsProvider from '@components/providers/ChannelsProvider';
 import Layout from '@components/layout';
-import initMockAPI from '@mocks/index';
 import ModalsProvider from '@components/providers/ModalProvider';
 import ShowModals from '@components/Modal/showModals';
+import MSWComponent from '@components/MSWComponent/MSWComponent';
 
-if (process.env.NODE_ENV === 'development') {
-  initMockAPI();
-}
+const isDevelopmentMode = process.env.NODE_ENV === 'development';
 
 export default function MyApp({ Component, pageProps }: AppProps) {
   const [queryClient] = useState(
@@ -27,6 +25,32 @@ export default function MyApp({ Component, pageProps }: AppProps) {
         },
       }),
   );
+
+  if (isDevelopmentMode) {
+    return (
+      <MSWComponent>
+        <QueryClientProvider client={queryClient}>
+          <Hydrate state={pageProps.dehydratedState}>
+            <ReactQueryDevtools initialIsOpen={false} />
+            <ChannelsProvider>
+              <ProfileProvider>
+                <LastVisitedBoardListsProvider>
+                  <MakeGameProvider>
+                    <ModalsProvider>
+                      <ShowModals />
+                      <Layout>
+                        <Component {...pageProps} />
+                      </Layout>
+                    </ModalsProvider>
+                  </MakeGameProvider>
+                </LastVisitedBoardListsProvider>
+              </ProfileProvider>
+            </ChannelsProvider>
+          </Hydrate>
+        </QueryClientProvider>
+      </MSWComponent>
+    );
+  }
 
   return (
     <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
## 🤠 개요
- 컴포넌트가 렌더링전에 msw가 켜지는 문제를 해결했어요.

- closes: #206 

## 💫 설명
개발모드인지 확인하고 개발모드가 아니라면 원래 컴포넌트를 바로 렌더링해요.
만약 개발모드라면 msw를 init한 후 컴포넌트를 렌더링할 수 있도록 변경했어요.



## 📷 스크린샷 (Optional)

- 기존, 렌더링 이후 msw init 실행

<img width="1115" alt="Screenshot 2023-10-30 at 10 54 00 PM" src="https://github.com/TheUpperPart/leaguehub-frontend/assets/100738049/7277ea66-d604-44af-8460-ad15b0df3565">

- 수정 후, msw init 이후 렌더링
<img width="1114" alt="Screenshot 2023-10-30 at 11 12 05 PM" src="https://github.com/TheUpperPart/leaguehub-frontend/assets/100738049/f50f82e0-e655-4583-8bbd-e8d24b7a5b5f">


