### PR TITLE
Feat/#205 헤더 문의하기 및 초대코드 복사 기능 추가

### DIFF
--- a/src/@types/icon.ts
+++ b/src/@types/icon.ts
@@ -14,4 +14,6 @@ export type IconKind =
   | 'modify'
   | 'setting'
   | 'cancel'
-  | 'shortcut';
+  | 'shortcut'
+  | 'message'
+  | 'mail';

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -37,32 +37,51 @@ const Header = () => {
       Cookies.remove('refreshToken');
 
       router.push('/');
-    } catch (error) {}
+    } catch (error) {
+      alert('로그아웃에 실패하였습니다.\n다시 시도해주세요');
+    }
+  };
+
+  const copyInviteCode = async () => {
+    const { channelLink } = router.query;
+    try {
+      await navigator.clipboard.writeText(channelLink as string);
+      alert('클립보드에 초대링크가 복사되었습니다.');
+    } catch (e) {
+      alert('복사에 실패하였습니다. 다시 시도해주세요');
+    }
   };
 
   return (
     <Headers>
       <Container>
-        {profileContext?.profile ? (
-          <LoginBtn onClick={handleDropDown}>
-            <ProfileImg
-              src={profileContext.profile.profileUrl}
-              width={24}
-              height={24}
-              alt='profile'
-            />
-            <Text>{profileContext.profile.nickname}</Text>
-            <DropDown click={clickDropdown}>
-              <DropList onClick={moveToMypage}>마이페이지</DropList>
-              <DropList onClick={handleLogout}>로그아웃</DropList>
-            </DropDown>
-          </LoginBtn>
-        ) : (
-          <LoginBtn onClick={handleLink}>
-            <Icon kind='my' color='white' size={24} />
-            <Text>로그인</Text>
-          </LoginBtn>
-        )}
+        <ContentsWrapper>
+          <Content onClick={copyInviteCode}>
+            <ContentText>초대코드</ContentText>
+            <Icon kind='mail' size={20} />
+          </Content>
+          <Content>
+            <ContentText>문의</ContentText>
+            <Icon kind='message' size={20} />
+          </Content>
+        </ContentsWrapper>
+        <MyInfo>
+          {profileContext?.profile && (
+            <LoginBtn onClick={handleDropDown}>
+              <ProfileImg
+                src={profileContext.profile.profileUrl}
+                width={24}
+                height={24}
+                alt='profile'
+              />
+              <Text>{profileContext.profile.nickname}</Text>
+              <DropDown click={clickDropdown}>
+                <DropList onClick={moveToMypage}>마이페이지</DropList>
+                <DropList onClick={handleLogout}>로그아웃</DropList>
+              </DropDown>
+            </LoginBtn>
+          )}
+        </MyInfo>
       </Container>
     </Headers>
   );
@@ -72,21 +91,50 @@ export default Header;
 
 const Headers = styled.header`
   width: calc(100% - 5rem);
-  margin: 0 2.5rem;
-  background-color: #f1f1f1;
 
+  margin: 0 2.5rem;
+
+  background-color: #f1f1f1;
   border-radius: 0 0 16px 16px;
 `;
 
 const Container = styled.div`
   width: 95%;
   height: 5.5rem;
+
+  margin: 0 auto;
   display: flex;
   align-items: center;
-  justify-content: flex-end;
-
-  position: relative;
+  justify-content: space-between;
 `;
+
+const ContentsWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const Content = styled.button`
+  height: 3.6rem;
+  border: none;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: 1rem;
+  padding: 0 1rem;
+
+  background-color: #ffffff;
+  border-radius: 10px;
+  font-size: 1.4rem;
+  cursor: pointer;
+`;
+
+const ContentText = styled.span`
+  margin-right: 1rem;
+`;
+
+const MyInfo = styled.div``;
 
 const ProfileImg = styled(Image)`
   border-radius: 50%;

--- a/src/components/Icon/index.tsx
+++ b/src/components/Icon/index.tsx
@@ -17,6 +17,8 @@ import {
   MdCancel,
   MdIndeterminateCheckBox,
   MdOutlineShortcut,
+  MdMessage,
+  MdEmail,
 } from 'react-icons/md';
 import { MouseEventHandler } from 'react';
 
@@ -37,6 +39,8 @@ const ICON: { [key in IconKind]: IconType } = {
   cancel: MdCancel,
   disqualification: MdIndeterminateCheckBox,
   shortcut: MdOutlineShortcut,
+  message: MdMessage,
+  mail: MdEmail,
 };
 
 interface IconProps {


### PR DESCRIPTION
## 🤠 개요

- closes: #205 
- 초대코드를 복사할 수 있도록 기능을 추가했어요.

## 💫 설명
- 초대코드를 복사할 수 있도록 기능을 추가했어요.
- 또, 문의하기도 컴포넌트는 만들어뒀는데 아직 어떻게 보여줄지 몰라서 기능 구현은 하지 않았어요.

- 아이콘은 일단 임의대로 사용했는데 나중에 디자인이 확정되면 해당 아이콘을 사용할게요.

- 그리고, 기존에는 헤더에 로그인 여부에 따라 보여주는 컴포넌트가 달랐는데 이제 로그인을 해야지만 헤더를 포함하는 화면으로 넘어갈 수 있어서 로그인하지 않았을 때 보여주던 로직을 제거했어요.


## 📷 스크린샷 (Optional)
<img width="1906" alt="Screenshot 2023-11-01 at 12 38 41 AM" src="https://github.com/TheUpperPart/leaguehub-frontend/assets/100738049/f613b7a8-889b-4c84-924f-7f92b707d36a">
