### PR TITLE
Feat/#210 로그아웃시 소개 페이지로 이동

### DIFF
--- a/src/@types/icon.ts
+++ b/src/@types/icon.ts
@@ -14,4 +14,6 @@ export type IconKind =
   | 'modify'
   | 'setting'
   | 'cancel'
-  | 'shortcut';
+  | 'shortcut'
+  | 'message'
+  | 'mail';

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -36,6 +36,7 @@ const Header = () => {
       Cookies.remove('accessToken');
       Cookies.remove('refreshToken');
 
+      await profileContext?.refetchProfile();
       router.push('/');
     } catch (error) {
       alert('로그아웃에 실패하였습니다.\n다시 시도해주세요');

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -37,32 +37,51 @@ const Header = () => {
       Cookies.remove('refreshToken');
 
       router.push('/');
-    } catch (error) {}
+    } catch (error) {
+      alert('로그아웃에 실패하였습니다.\n다시 시도해주세요');
+    }
+  };
+
+  const copyInviteCode = async () => {
+    const { channelLink } = router.query;
+    try {
+      await navigator.clipboard.writeText(channelLink as string);
+      alert('클립보드에 초대링크가 복사되었습니다.');
+    } catch (e) {
+      alert('복사에 실패하였습니다. 다시 시도해주세요');
+    }
   };
 
   return (
     <Headers>
       <Container>
-        {profileContext?.profile ? (
-          <LoginBtn onClick={handleDropDown}>
-            <ProfileImg
-              src={profileContext.profile.profileUrl}
-              width={24}
-              height={24}
-              alt='profile'
-            />
-            <Text>{profileContext.profile.nickname}</Text>
-            <DropDown click={clickDropdown}>
-              <DropList onClick={moveToMypage}>마이페이지</DropList>
-              <DropList onClick={handleLogout}>로그아웃</DropList>
-            </DropDown>
-          </LoginBtn>
-        ) : (
-          <LoginBtn onClick={handleLink}>
-            <Icon kind='my' color='white' size={24} />
-            <Text>로그인</Text>
-          </LoginBtn>
-        )}
+        <ContentsWrapper>
+          <Content onClick={copyInviteCode}>
+            <ContentText>초대코드</ContentText>
+            <Icon kind='mail' size={20} />
+          </Content>
+          <Content>
+            <ContentText>문의</ContentText>
+            <Icon kind='message' size={20} />
+          </Content>
+        </ContentsWrapper>
+        <MyInfo>
+          {profileContext?.profile && (
+            <LoginBtn onClick={handleDropDown}>
+              <ProfileImg
+                src={profileContext.profile.profileUrl}
+                width={24}
+                height={24}
+                alt='profile'
+              />
+              <Text>{profileContext.profile.nickname}</Text>
+              <DropDown click={clickDropdown}>
+                <DropList onClick={moveToMypage}>마이페이지</DropList>
+                <DropList onClick={handleLogout}>로그아웃</DropList>
+              </DropDown>
+            </LoginBtn>
+          )}
+        </MyInfo>
       </Container>
     </Headers>
   );
@@ -72,21 +91,50 @@ export default Header;
 
 const Headers = styled.header`
   width: calc(100% - 5rem);
-  margin: 0 2.5rem;
-  background-color: #f1f1f1;
 
+  margin: 0 2.5rem;
+
+  background-color: #f1f1f1;
   border-radius: 0 0 16px 16px;
 `;
 
 const Container = styled.div`
   width: 95%;
   height: 5.5rem;
+
+  margin: 0 auto;
   display: flex;
   align-items: center;
-  justify-content: flex-end;
-
-  position: relative;
+  justify-content: space-between;
 `;
+
+const ContentsWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const Content = styled.button`
+  height: 3.6rem;
+  border: none;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: 1rem;
+  padding: 0 1rem;
+
+  background-color: #ffffff;
+  border-radius: 10px;
+  font-size: 1.4rem;
+  cursor: pointer;
+`;
+
+const ContentText = styled.span`
+  margin-right: 1rem;
+`;
+
+const MyInfo = styled.div``;
 
 const ProfileImg = styled(Image)`
   border-radius: 50%;

--- a/src/components/Icon/index.tsx
+++ b/src/components/Icon/index.tsx
@@ -17,6 +17,8 @@ import {
   MdCancel,
   MdIndeterminateCheckBox,
   MdOutlineShortcut,
+  MdMessage,
+  MdEmail,
 } from 'react-icons/md';
 import { MouseEventHandler } from 'react';
 
@@ -37,6 +39,8 @@ const ICON: { [key in IconKind]: IconType } = {
   cancel: MdCancel,
   disqualification: MdIndeterminateCheckBox,
   shortcut: MdOutlineShortcut,
+  message: MdMessage,
+  mail: MdEmail,
 };
 
 interface IconProps {

--- a/src/components/providers/ProfileProvider.tsx
+++ b/src/components/providers/ProfileProvider.tsx
@@ -47,6 +47,10 @@ const ProfileProvider = ({ children }: ProfileProviderProps) => {
     }
   }, [profileQuery.data]);
 
+  const refetchProfile = async () => {
+    await profileQuery.refetch();
+  };
+
   return (
     <ProfileContext.Provider
       value={{
@@ -54,6 +58,7 @@ const ProfileProvider = ({ children }: ProfileProviderProps) => {
         setProfile,
         status: profileQuery.status,
         isInitialLoading: profileQuery.isInitialLoading,
+        refetchProfile,
       }}
     >
       {children}

--- a/src/contexts/ProfileContext.tsx
+++ b/src/contexts/ProfileContext.tsx
@@ -7,6 +7,7 @@ interface ProfileState {
   setProfile: React.Dispatch<React.SetStateAction<Profile | null>>;
   status: 'loading' | 'error' | 'success';
   isInitialLoading: boolean;
+  refetchProfile: () => Promise<void>;
 }
 
 const ProfileContext = createContext<ProfileState | null>(null);


### PR DESCRIPTION
## 🤠 개요

- closes: #210 
- 로그아웃시 소개 페이지로 이동하도록 변경했어요.


## 💫 설명
- 기존에 로그아웃에 성공했을 때, 토큰만 쿠키에서 삭제하고 계속 로그인되었을 때 확인할 수 있는 페이지에 머물렀어요.
- 따라서, 로그아웃을 하면 로그인 하지 않았을 때 메인 페이지(소개 페이지)를 보여주기 위해서 profile api를 refetch하도록했어요.
- 토큰이 존재하지 않으니 해당 api 호출에 실패하고 소개 페이지를 보여주게 돼요.

## 📷 스크린샷 (Optional)

- 이전
![이전](https://github.com/TheUpperPart/leaguehub-frontend/assets/100738049/771e6f2f-5295-4d42-aa70-42ad847b48e4)

- 이후
![이후](https://github.com/TheUpperPart/leaguehub-frontend/assets/100738049/c32abe3a-6fbc-4292-a40f-48d59db206c3)


