### PR TITLE
Feat/#214 로딩 컴포넌트 생성 및 layout에 적용

### DIFF
--- a/src/components/Loading/Loading.tsx
+++ b/src/components/Loading/Loading.tsx
@@ -1,0 +1,45 @@
+import styled from '@emotion/styled';
+
+const Loading = () => {
+  return (
+    <Main>
+      <svg
+        width='38'
+        height='38'
+        viewBox='0 0 38 38'
+        xmlns='http://www.w3.org/2000/svg'
+        stroke='#fff'
+      >
+        <g fill='none' fillRule='evenodd'>
+          <g transform='translate(1 1)' strokeWidth='2'>
+            <circle strokeOpacity='.5' cx='18' cy='18' r='18' />
+            <path d='M36 18c0-9.94-8.06-18-18-18'>
+              <animateTransform
+                attributeName='transform'
+                type='rotate'
+                from='0 18 18'
+                to='360 18 18'
+                dur='1s'
+                repeatCount='indefinite'
+              />
+            </path>
+          </g>
+        </g>
+      </svg>
+    </Main>
+  );
+};
+
+const Main = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  width: 100%;
+  height: 100vh;
+  background: url('/img/main/main.png');
+  background-size: 100% 100vh;
+  background-repeat: no-repeat;
+`;
+
+export default Loading;

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -8,6 +8,7 @@ import Header from '@components/Header/Header';
 import useChannels from '@hooks/useChannels';
 import useProfile from '@hooks/useProfile';
 import NoAuthMain from './Main/NoAuthMain';
+import Loading from './Loading/Loading';
 
 const Layout = ({ children }: PropsWithChildren) => {
   const { channels } = useChannels();
@@ -32,7 +33,7 @@ const Layout = ({ children }: PropsWithChildren) => {
       <>
         <CommonLayout>
           <GlobalStyle />
-          <div>Loading...</div>
+          <Loading />
         </CommonLayout>
       </>
     );


### PR DESCRIPTION
## 🤠 개요

- closes: #214 
- 로딩 컴포넌트를 생성했어요. 
## 💫 설명
우선 최초에 로그인 여부를 판단할 때 사용하려고  background를 main.png를 사용했어요. 추후에 많은 곳에서 사용하려고 하면 Props로 background url을 받거나 이미지를 로딩 컴포넌트에서 제거해야할 것 같아요
## 📷 스크린샷 (Optional)
![ㅇㅇㅇ](https://github.com/TheUpperPart/leaguehub-frontend/assets/100738049/c717bc7c-11cc-4732-901b-97a2d58285db)
