### PR TITLE
Fix/#216 라운드 대진 횟수 설정 에러 해결

### DIFF
--- a/src/@types/channelConfig.ts
+++ b/src/@types/channelConfig.ts
@@ -1,3 +1,3 @@
 export interface MatchCountList {
-  roundCountList: number[];
+  matchSetCountList: number[];
 }

--- a/src/components/ModifyChannel/BracketInfoChannel.tsx
+++ b/src/components/ModifyChannel/BracketInfoChannel.tsx
@@ -21,7 +21,6 @@ const BracketInfoChannel = () => {
   const { data, isLoading, isError, isSuccess } = useQuery({
     queryKey: ['matchCount', router.query.channelLink as string],
     queryFn: () => fetchInitialMatchCount(router.query.channelLink as string),
-    cacheTime: 0,
     staleTime: 0,
   });
 

--- a/src/components/ModifyChannel/BracketInfoChannel.tsx
+++ b/src/components/ModifyChannel/BracketInfoChannel.tsx
@@ -21,6 +21,8 @@ const BracketInfoChannel = () => {
   const { data, isLoading, isError, isSuccess } = useQuery({
     queryKey: ['matchCount', router.query.channelLink as string],
     queryFn: () => fetchInitialMatchCount(router.query.channelLink as string),
+    cacheTime: 0,
+    staleTime: 0,
   });
 
   const handleRoundInfo = (e: React.ChangeEvent<HTMLSelectElement>, roundIndex: number) => {
@@ -32,34 +34,47 @@ const BracketInfoChannel = () => {
   };
 
   const updateRoundMatchCount = async () => {
+    if (!roundInfo) {
+      return;
+    }
+
     try {
       const res = await authAPI({
         method: 'post',
         url: `/api/match/${router.query.channelLink as string}/count`,
         data: {
-          roundCountList: roundInfo?.reverse(),
+          matchSetCountList: [...roundInfo].reverse(),
         },
       });
-
-      console.log(res);
 
       alert('수정이 완료되었습니다!');
     } catch (error) {
       console.log(error);
+      alert('이미 시작된 경기는 재 배정할 수 없습니다.');
     }
   };
 
   useEffect(() => {
     if (isSuccess) {
-      setRoundInfo(data?.roundCountList.reverse());
+      setRoundInfo([...data?.matchSetCountList].reverse());
     }
   }, [data]);
+
+  if (isLoading) {
+    return <div>로딩 중</div>;
+  }
+
+  if (isError) {
+    return <div>에러</div>;
+  }
 
   return (
     <Container>
       <Header>라운드 수정</Header>
       <Content>
-        {roundInfo?.map((currentMatchCount, index) => {
+        {isLoading && <div>로딩 중</div>}
+        {isError && <div>Error</div>}
+        {roundInfo?.reverse().map((currentMatchCount, index) => {
           return (
             <RoundInfo key={index}>
               <RoundInfoHeader>Round {index + 1}</RoundInfoHeader>

--- a/src/components/RoundAlarm/RoundAlarmBody.tsx
+++ b/src/components/RoundAlarm/RoundAlarmBody.tsx
@@ -13,8 +13,6 @@ interface Props {
 const RoundAlarmBody = ({ curRound, havingAlarm }: Props) => {
   const router = useRouter();
 
-  console.log(havingAlarm);
-
   const [roundInfo, setRoundInfo] = useState<BracketContents>();
 
   useEffect(() => {


### PR DESCRIPTION
## 🤠 개요

- closes: #216 

- 대진표 수정 버튼을 누르면 에러 뜨던 문제 해결
- 횟수를 수정하면 역으로 수정되던 문제 해결


## 💫 설명
- 대진표 수정 버튼을 누르면 에러 뜨던 문제가 있었는데 서버의 response type이 변경되어서 발생한 문제여서 서버의 응답 타입에 맞게 타입을 변경해서 해결했어요.
- 8강의 횟수를 3회에서 5회로 수정하면 32강에 적용되던 문제가 있었어요. 그 이유가 서버에서 8강 16강 32강 데이터를 주면 프론트에서 32강 16강 8강으로 변경해서 데이터를 보여주고 횟수를 수정하면 다시 8강 16강 32강으로 변경해서 서버에 요청을 해야하는데 중간중간 reverse 메서드를 사용했는데 reverse 메서드는 원본 배열을 수정해서 발생하던 문제였어요.
- 따라서, 깊은 복사를 통해서 원본 배열을 건드리지 않고 reverse를 사용했어요.

## 📷 스크린샷 (Optional)
