### PR TITLE
Fix: 이미지 업로드 버튼 표시

### DIFF
--- a/src/components/MakeChannel/SelectRule.tsx
+++ b/src/components/MakeChannel/SelectRule.tsx
@@ -167,13 +167,17 @@ const SelectRule = ({ handleCurrentModalStep }: Props) => {
         </Rule>
         <Rule>
           <RuleTitle>4. 대회 이미지(선택)</RuleTitle>
-          <ImageUploadInput
-            type='file'
-            accept='image/*'
-            ref={inputRef}
-            onChange={fetchUploadChannelImage}
-          />
-          {imageUrl && <Image width={50} height={50} src={imageUrl} alt='channelImage' />}
+          <ImageContainer>
+            <ImageUploadInput
+              type='file'
+              accept='image/*'
+              ref={inputRef}
+              onChange={fetchUploadChannelImage}
+            />
+            <ImagePreview>
+              {imageUrl && <Image width={50} height={50} src={imageUrl} alt='channelImage' />}
+            </ImagePreview>
+          </ImageContainer>
         </Rule>
         <StepBtnContainer>
           <Button width={25} height={7} borderRadius={1} onClick={fetchMakeGame}>
@@ -265,12 +269,18 @@ const StepBtnContainer = styled.div`
 `;
 
 const ImageUploadInput = styled.input`
-  position: absolute;
-  width: 0;
-  height: 0;
   padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
   border: 0;
+  flex: 1;
+`;
+
+const ImageContainer = styled.div`
+  height: 100px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const ImagePreview = styled.div`
+  flex: 1;
 `;


### PR DESCRIPTION
## 🤠 개요

- closes: #219 
- 이미지 업로드 버튼이 보이지 않던 문제를 수정했어요.

## 💫 설명
- 이미지 업로드 버튼을 커스텀할 예정이여서 기존 업로드 버튼의`width`와 `height`를 0으로 설정했는데 아직 디자인이 확정되지 않아 보이도록 변경했어요.
- 추후에 이미지 업로드 커스텀 버튼 디자인이 확정되면 해당 디자인을 적용할게요.

## 📷 스크린샷 (Optional)
<img width="477" alt="Screenshot 2023-11-06 at 12 29 28 AM" src="https://github.com/TheUpperPart/leaguehub-frontend/assets/100738049/14ed3124-ced3-48b0-b68b-03dc0c192ddc">

