### PR TITLE
Fix/#215: 채팅 기능 수정

### DIFF
--- a/__mocks__/handlers/matchHandlers.ts
+++ b/__mocks__/handlers/matchHandlers.ts
@@ -107,7 +107,7 @@ const players: GetMatchPlayerScoreInfos = {
   ],
   matchMessages: [
     {
-      channelId: 123,
+      channelLink: 123,
       content: '안녕하세요',
       matchId: 1,
       participantId: 1,
@@ -115,7 +115,7 @@ const players: GetMatchPlayerScoreInfos = {
       type: 'TEXT',
     },
     {
-      channelId: 123,
+      channelLink: 123,
       content: '네 안녕하세요',
       matchId: 2,
       participantId: 2,
@@ -123,7 +123,7 @@ const players: GetMatchPlayerScoreInfos = {
       type: 'TEXT',
     },
     {
-      channelId: 123,
+      channelLink: 123,
       content: '이경훈 욕설 신고요',
       matchId: 3,
       participantId: 3,
@@ -131,7 +131,7 @@ const players: GetMatchPlayerScoreInfos = {
       type: 'TEXT',
     },
     {
-      channelId: 123,
+      channelLink: 123,
       content: 'ㅅㄱㅇ',
       matchId: 4,
       participantId: 4,
@@ -139,7 +139,14 @@ const players: GetMatchPlayerScoreInfos = {
       type: 'TEXT',
     },
     {
-      channelId: 123,
+      channelLink: 123,
+      content: '관리자 호출',
+      matchId: 4,
+      timestamp: '2023-10-09T07:03:06.959Z',
+      type: 'ALERT',
+    },
+    {
+      channelLink: 123,
       content: '근데 이경훈이 누구임?',
       matchId: 4,
       participantId: 4,
@@ -147,7 +154,7 @@ const players: GetMatchPlayerScoreInfos = {
       type: 'TEXT',
     },
     {
-      channelId: 123,
+      channelLink: 123,
       content:
         '이 편지는 영국에서 최초로 시작되어 일년에 한바퀴를 돌면서 받는 사람에게 행운을 주었고 지금은 당신에게로 옮겨진 이 편지는 4일 안에 당신 곁을 떠나야 합니다. 이 편지를 포함해서 7통을 행운이 필요한 사람에게 보내 주셔야 합니다. 복사를 해도 좋습니다. 혹 미신이라 하실지 모르지만 사실입니다.',
       matchId: 8,

--- a/src/components/RoundCheckIn/CallAdminChat.tsx
+++ b/src/components/RoundCheckIn/CallAdminChat.tsx
@@ -152,7 +152,7 @@ const CallAdminChat = ({
           chats.map((message, idx) => (
             <ChattingInfo key={idx}>
               {message.type === 'ALERT' ? (
-                <AlertWrapper>관리자를 호출하였습니다</AlertWrapper>
+                <AlertWrapper>누군가 관리자를 호출하였습니다</AlertWrapper>
               ) : (
                 <ChattingContent>
                   {requestUser === findRequestUser(message.participantId) ? (
@@ -233,7 +233,12 @@ const ChattingWrapper = styled.div`
   overflow: scroll;
 `;
 
-const AlertWrapper = styled.div``;
+const AlertWrapper = styled.div`
+  background-color: #e2e2e2;
+  padding: 0.7rem;
+  margin: 0 auto;
+  border-radius: 0.4rem;
+`;
 
 const ImageWrapper = styled.div`
   border-radius: 0.3rem;

--- a/src/components/RoundCheckIn/CallAdminChat.tsx
+++ b/src/components/RoundCheckIn/CallAdminChat.tsx
@@ -101,20 +101,21 @@ const CallAdminChat = ({
     });
   };
 
-  const findUserIMG = (playerParticipantId: number): string => {
+  const findUserIMG = (playerParticipantId: number | undefined): string => {
     const user = players.find((player) => player.participantId === playerParticipantId);
 
     if (!user) return BASE_PROFILE_IMG;
     return user.profileSrc;
   };
 
-  const findUserName = (playerParticipantId: number): string => {
-    const user = players.find((player) => player.participantId === playerParticipantId);
-    if (!user) return '관리자';
+  const findUserName = (message: MatchMessages): string => {
+    const user = players.find((player) => player.participantId === message.participantId);
+
+    if (!user) return message.adminName ? message.adminName : '관리자';
     return user.gameId;
   };
 
-  const findRequestUser = (playerParticipantId: number): number => {
+  const findRequestUser = (playerParticipantId: number | undefined): number => {
     const user = players.find((player) => player.participantId === playerParticipantId);
     if (!user) return -1;
     return user.matchPlayerId;
@@ -150,28 +151,32 @@ const CallAdminChat = ({
         {chats.length !== 0 &&
           chats.map((message, idx) => (
             <ChattingInfo key={idx}>
-              <ChattingContent>
-                {requestUser === findRequestUser(message.participantId) ? (
-                  <MyChattingContent>
-                    <MyContentText>{message.content}</MyContentText>
-                  </MyChattingContent>
-                ) : (
-                  <>
-                    <ImageWrapper>
-                      <Image
-                        src={findUserIMG(message.participantId)}
-                        alt='프로필사진'
-                        width={45}
-                        height={45}
-                      />
-                    </ImageWrapper>
-                    <ContentWrapper>
-                      <ContentName>{findUserName(message.participantId)}</ContentName>
-                      <ContentText>{message.content}</ContentText>
-                    </ContentWrapper>
-                  </>
-                )}
-              </ChattingContent>
+              {message.type === 'ALERT' ? (
+                <AlertWrapper>관리자를 호출하였습니다</AlertWrapper>
+              ) : (
+                <ChattingContent>
+                  {requestUser === findRequestUser(message.participantId) ? (
+                    <MyChattingContent>
+                      <MyContentText>{message.content}</MyContentText>
+                    </MyChattingContent>
+                  ) : (
+                    <>
+                      <ImageWrapper>
+                        <Image
+                          src={findUserIMG(message.participantId)}
+                          alt='프로필사진'
+                          width={45}
+                          height={45}
+                        />
+                      </ImageWrapper>
+                      <ContentWrapper>
+                        <ContentName>{findUserName(message)}</ContentName>
+                        <ContentText>{message.content}</ContentText>
+                      </ContentWrapper>
+                    </>
+                  )}
+                </ChattingContent>
+              )}
             </ChattingInfo>
           ))}
         <div ref={chatEndRef} />
@@ -227,6 +232,8 @@ const ChattingWrapper = styled.div`
   height: 40rem;
   overflow: scroll;
 `;
+
+const AlertWrapper = styled.div``;
 
 const ImageWrapper = styled.div`
   border-radius: 0.3rem;

--- a/src/components/RoundCheckIn/CallAdminChat.tsx
+++ b/src/components/RoundCheckIn/CallAdminChat.tsx
@@ -6,6 +6,7 @@ import { Client } from '@stomp/stompjs';
 import React, { useEffect, useState, ChangeEvent, useRef } from 'react';
 import { useRouter } from 'next/router';
 import { BASE_PROFILE_IMG } from '@config/index';
+import Cookies from 'js-cookie';
 
 interface CallAdminChatProps {
   client: Client | undefined;
@@ -45,17 +46,33 @@ const CallAdminChat = ({
 
   const sendMessage = () => {
     if (!client || inputMessage.length === 0) return;
-    const requestUserParticipantId = players.find(
-      (player) => player.matchPlayerId === requestUser,
-    )?.participantId;
 
-    const newMessage = {
-      channelLink,
-      content: inputMessage,
-      matchId,
-      participantId: requestUserParticipantId,
-      type: 'TEXT',
-    };
+    let newMessage;
+
+    if (requestUser === -1) {
+      const accessToken = Cookies.get('accessToken');
+
+      newMessage = {
+        channelLink,
+        content: inputMessage,
+        matchId,
+        accessToken,
+        type: 'ADMIN',
+      };
+    } else {
+      const requestUserParticipantId = players.find(
+        (player) => player.matchPlayerId === requestUser,
+      )?.participantId;
+
+      newMessage = {
+        channelLink,
+        content: inputMessage,
+        matchId,
+        participantId: requestUserParticipantId,
+        type: 'USER',
+      };
+    }
+
     client.publish({
       destination: `/app/match/chat`,
       body: JSON.stringify(newMessage),

--- a/src/components/RoundCheckIn/index.tsx
+++ b/src/components/RoundCheckIn/index.tsx
@@ -26,9 +26,9 @@ export interface MatchMessages {
   channelLink: number;
   content: string;
   matchId: number;
-  participantId: number;
-  adminName: string;
-  accessToken: string;
+  participantId?: number;
+  adminName?: string;
+  timestamp: string;
   type: string;
 }
 

--- a/src/components/RoundCheckIn/index.tsx
+++ b/src/components/RoundCheckIn/index.tsx
@@ -23,11 +23,12 @@ export interface MatchPlayerScoreInfos {
 }
 
 export interface MatchMessages {
-  channelId: number;
+  channelLink: number;
   content: string;
   matchId: number;
   participantId: number;
-  timestamp: string;
+  adminName: string;
+  accessToken: string;
   type: string;
 }
 


### PR DESCRIPTION
## 🤠 개요

- closes: #215 
- 채팅이 안되는 문제를 해결했어요
- 'ALERT' 타입의 채팅 UI 가 추가됐어요
- 관리자가 채팅치면 어떤 관리자가 채팅을 보냈는지 이름을 확인할 수 있어요
<!--
- 이슈번호
- 한줄 설명
- closes: #(이슈번호 입력해주세요)
  -->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
<img width="1728" alt="image" src="https://github.com/TheUpperPart/leaguehub-frontend/assets/71641127/1f6c1036-1738-4475-bb62-bcc8760b3009">
