### PR TITLE
Feat/#229: 채널 별 메인 홈 화면 추가

### DIFF
--- a/__mocks__/handlers/channelHandlers.ts
+++ b/__mocks__/handlers/channelHandlers.ts
@@ -1,6 +1,7 @@
 import { rest } from 'msw';
 import { SERVER_URL } from '@config/index';
 import { ChannelCircleProps } from '@type/channelCircle';
+import { MainContent } from '@pages/contents/[channelLink]/main';
 
 const getChannels: ChannelCircleProps[][] = [
   [
@@ -73,6 +74,17 @@ const channelHandlers = [
   }),
   rest.post(SERVER_URL + '/api/:channelLink/participant', (req, res, ctx) => {
     return res(ctx.status(200), ctx.json({}));
+  }),
+  rest.get(SERVER_URL + '/api/channel/:channelLink/main', (req, res, ctx) => {
+    const mockMainContent: MainContent = {
+      channelTitleInfo: '제목제목',
+      channelContentInfo: '소제목소제목 내용내용 가나다라마바사',
+      channelRuleInfo: '참가조건이 들어가는 내용입니다',
+      channelTimeInfo: '대회 일정이 들어가는 내용입니다',
+      channelPrizeInfo: '대회 경품이 들어가는 내용임 ㅇㅇ',
+    };
+
+    return res(ctx.status(200), ctx.json(mockMainContent));
   }),
 ];
 

--- a/src/components/Card/HomeCard.tsx
+++ b/src/components/Card/HomeCard.tsx
@@ -1,0 +1,38 @@
+import styled from '@emotion/styled';
+
+interface HomeCardProps {
+  onClick?: () => void;
+  contents: string | undefined;
+}
+
+const HomeCard = ({ onClick, contents }: HomeCardProps) => {
+  return (
+    <Container onClick={onClick} hasOnClick={!!onClick}>
+      {contents ? contents : ''}
+    </Container>
+  );
+};
+
+export default HomeCard;
+
+const Container = styled.div<{ hasOnClick: boolean }>`
+  width: 22%;
+  height: 30rem;
+  display: flex;
+  align-items: center;
+  text-align: center;
+  background-color: white;
+  border-radius: 1rem;
+  font-size: 2rem;
+  justify-content: center;
+  box-shadow: rgba(100, 100, 111, 0.2) 0px 7px 29px 0px;
+
+  ${({ hasOnClick }) =>
+    hasOnClick &&
+    `
+  &:hover {
+    background-color: lightgray;
+    cursor: pointer;
+  }
+`}
+`;

--- a/src/components/Content/MainContentModify.tsx
+++ b/src/components/Content/MainContentModify.tsx
@@ -1,0 +1,128 @@
+import styled from '@emotion/styled';
+import { MainContent } from '@pages/contents/[channelLink]/main';
+import { MouseEventHandler, useRef } from 'react';
+
+interface MainContentModify {
+  onUpdateContent: (updatedContent: MainContent) => void;
+  mainContent: MainContent | undefined;
+}
+
+const MainContentModify = ({ onUpdateContent, mainContent }: MainContentModify) => {
+  const subTitleRef = useRef<HTMLInputElement>(null);
+  const channelRuleRef = useRef<HTMLTextAreaElement>(null);
+  const channelTimeInfoRef = useRef<HTMLTextAreaElement>(null);
+  const channelPrizeInfoRef = useRef<HTMLTextAreaElement>(null);
+
+  const onClick: MouseEventHandler<HTMLElement> = () => {
+    if (!confirm('내용을 수정하시겠습니까?')) return;
+    const subTitle = subTitleRef.current?.value;
+    const channelRule = channelRuleRef.current?.value;
+    const channelTimeInfo = channelTimeInfoRef.current?.value;
+    const channelPrizeInfo = channelPrizeInfoRef.current?.value;
+    if (
+      !subTitle ||
+      !channelRule ||
+      !channelTimeInfo ||
+      !channelPrizeInfo ||
+      !mainContent?.channelTitleInfo
+    ) {
+      alert('빈 칸을 입력해주세요');
+      return;
+    }
+
+    const updatedContent: MainContent = {
+      channelTitleInfo: mainContent?.channelTitleInfo,
+      channelContentInfo: subTitle,
+      channelRuleInfo: channelRule,
+      channelTimeInfo: channelTimeInfo,
+      channelPrizeInfo: channelPrizeInfo,
+    };
+
+    onUpdateContent(updatedContent);
+  };
+
+  return (
+    <>
+      <Title>{mainContent?.channelTitleInfo}</Title>
+      <SubTitle>
+        <InputField
+          placeholder='설명을 추가해주세요'
+          defaultValue={mainContent?.channelContentInfo}
+          ref={subTitleRef}
+        />
+      </SubTitle>
+      <HomeCardWrapper>
+        <TextAreaField
+          placeholder='참가조건을 입력해주세요'
+          defaultValue={mainContent?.channelRuleInfo}
+          ref={channelRuleRef}
+        />
+        <TextAreaField
+          placeholder='대회 일정을 입력해주세요'
+          defaultValue={mainContent?.channelTimeInfo}
+          ref={channelTimeInfoRef}
+        />
+        <TextAreaField
+          placeholder='대진표 바로가기'
+          defaultValue='대진표 바로가기'
+          disabled={true}
+        />
+        <TextAreaField
+          placeholder='대회 경품을 입력해주세요'
+          defaultValue={mainContent?.channelPrizeInfo}
+          ref={channelPrizeInfoRef}
+        />
+      </HomeCardWrapper>
+      <ModifyButton onClick={onClick}>수정 완료</ModifyButton>
+    </>
+  );
+};
+
+export default MainContentModify;
+
+const Title = styled.div`
+  padding-top: 10rem;
+  font-size: 2.5rem;
+  font-weight: bold;
+`;
+
+const SubTitle = styled.div`
+  font-size: 1.5rem;
+  padding: 5rem 0 5rem;
+`;
+
+const InputField = styled.input`
+  width: 80%;
+  height: 5vh;
+  border-radius: 1rem;
+  padding-left: 1rem;
+`;
+
+const HomeCardWrapper = styled.div`
+  display: flex;
+  column-gap: 2rem;
+`;
+
+const TextAreaField = styled.textarea`
+  width: 22%;
+  height: 30rem;
+  box-shadow: rgba(100, 100, 111, 0.2) 0px 7px 29px 0px;
+  padding: 1rem;
+  border-radius: 1rem;
+`;
+
+const ModifyButton = styled.button`
+  font-size: 2rem;
+  color: white;
+  position: fixed;
+  bottom: 3rem;
+  right: 5rem;
+  border: none;
+  padding: 1rem;
+  border-radius: 1rem;
+  background-color: #0067a3;
+
+  &: hover {
+    cursor: pointer;
+  }
+`;

--- a/src/components/MakeChannel/SelectRule.tsx
+++ b/src/components/MakeChannel/SelectRule.tsx
@@ -69,7 +69,7 @@ const SelectRule = ({ handleCurrentModalStep, handleModal }: Props) => {
         },
       });
       resetState();
-      router.push('/main');
+      router.push('/');
       handleModal();
       addChannel(res.data);
     } catch (error) {

--- a/src/components/Sidebar/BoardBar/BoardBody.tsx
+++ b/src/components/Sidebar/BoardBar/BoardBody.tsx
@@ -164,7 +164,11 @@ const BoardBody = ({ channelLink }: Props) => {
           {(provided) => (
             <div ref={provided.innerRef} {...provided.droppableProps}>
               {isSuccess && data.myMatchRound !== 0 && (
-                <div>
+                <div
+                  css={css`
+                    padding-left: 0.5rem;
+                  `}
+                >
                   <Title>현재 라운드</Title>
                   <BoardContainer
                     onClick={() => {
@@ -189,7 +193,14 @@ const BoardBody = ({ channelLink }: Props) => {
               )}
               <AdminTable>
                 <Title>대회</Title>
-                <NoticeScrollContainer></NoticeScrollContainer>
+                <BoardContainer
+                  isSelected={selected === 'main'}
+                  data-id='main'
+                  data-board-title='메인'
+                  onClick={onClickBoard}
+                >
+                  홈
+                </BoardContainer>
                 {channelPermission === 0 && (
                   <BoardContainer
                     isSelected={selected === 'admin'}
@@ -275,7 +286,7 @@ const Container = styled.ul`
 const CurrentRound = styled.div`
   display: flex;
   justify-content: space-between;
-  width: 100%;
+  width: 90%;
 `;
 
 const RedCircle = styled.div`
@@ -299,7 +310,6 @@ const Title = styled.div`
 
 const AdminTable = styled.div`
   width: 19.2rem;
-  height: 12.8rem;
 
   margin: 0 auto;
   display: flex;
@@ -327,7 +337,9 @@ const ScrollContainer = styled.div`
   }
 `;
 
-const NoticeTable = styled.div``;
+const NoticeTable = styled.div`
+  padding-top: 1rem;
+`;
 
 const NoticeScrollContainer = styled.div`
   display: flex;
@@ -341,13 +353,14 @@ const BoardContainer = styled.li<{ isSelected: boolean }>`
   height: 4.8rem;
   display: flex;
   align-items: center;
+  padding-left: 1rem;
 
   &:hover {
     background-color: #aec3ae;
   }
 
   background-color: #ffffff;
-  font-size: 1.4rem;
+  font-size: 1.3rem;
   cursor: pointer;
   color: #000000;
   border-radius: 6px;

--- a/src/components/Sidebar/BoardBar/BoardBody.tsx
+++ b/src/components/Sidebar/BoardBar/BoardBody.tsx
@@ -134,9 +134,9 @@ const BoardBody = ({ channelLink }: Props) => {
     }
 
     if (isSuccess) {
-      const tmpBoards = data.channelBoardLoadDtoList;
-      selectBoardId(tmpBoards[0].boardId.toString());
-      handleBoard(channelLink, tmpBoards[0].boardId.toString(), tmpBoards[0].boardTitle);
+      selectBoardId('main');
+      // const tmpBoards = data.channelBoardLoadDtoList;
+      // handleBoard(channelLink, tmpBoards[0].boardId.toString(), tmpBoards[0].boardTitle);
     }
   }, [channelLink, isSuccess]);
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,5 +1,5 @@
-let SERVER_URL = 'http://54.180.1.85:8080';
-const SOCKET_URL = 'ws://54.180.1.85:8080/ws/websocket';
+let SERVER_URL = 'http://3.38.168.158:8080';
+const SOCKET_URL = 'ws://3.38.168.158:8080/ws/websocket';
 
 if (process.env.NODE_ENV === 'development') {
   SERVER_URL = 'http://localhost:8080';

--- a/src/pages/contents/[channelLink]/main.tsx
+++ b/src/pages/contents/[channelLink]/main.tsx
@@ -1,0 +1,128 @@
+import authAPI from '@apis/authAPI';
+import HomeCard from '@components/Card/HomeCard';
+import MainContentModify from '@components/Content/MainContentModify';
+import Loading from '@components/Loading/Loading';
+import styled from '@emotion/styled';
+import useChannels from '@hooks/useChannels';
+import { useQuery } from '@tanstack/react-query';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+
+export interface MainContent {
+  readonly channelTitleInfo: string;
+  readonly channelContentInfo: string;
+  readonly channelRuleInfo: string;
+  readonly channelTimeInfo: string;
+  readonly channelPrizeInfo: string;
+}
+
+const fetchData = async (channelLink: string): Promise<MainContent | undefined> => {
+  const res = await authAPI<MainContent>({
+    method: 'get',
+    url: `/api/channel/${channelLink}/main`,
+  });
+
+  if (res.status !== 200) {
+    return;
+  }
+
+  return res.data;
+};
+
+const Main = () => {
+  const [mainContents, setMainContents] = useState<MainContent>();
+  const [isModify, setIsModify] = useState(false);
+
+  const router = useRouter();
+  const { channelPermission } = useChannels();
+  const channelLink = router.query.channelLink;
+
+  const { data, isLoading, isSuccess } = useQuery<MainContent | undefined>(
+    ['getMainContents', channelLink],
+    () => {
+      return fetchData(channelLink as string);
+    },
+  );
+
+  useEffect(() => {
+    if (isSuccess && data) setMainContents(data);
+  }, [isSuccess]);
+
+  if (isLoading) {
+    return <Loading />;
+  }
+
+  const handleContentUpdate = async (updatedContent: MainContent) => {
+    if (!channelLink) return;
+
+    const res = await authAPI({ method: 'post', url: `/api/channel/${channelLink}/main` });
+    if (res.status !== 200) return router.push('/');
+
+    setMainContents(updatedContent);
+    setIsModify(false);
+  };
+
+  return (
+    <Container>
+      {isModify ? (
+        <MainContentModify onUpdateContent={handleContentUpdate} mainContent={mainContents} />
+      ) : (
+        <>
+          <Title>{mainContents?.channelTitleInfo}</Title>
+          <SubTitle>{mainContents?.channelContentInfo}</SubTitle>
+
+          <HomeCardWrapper>
+            <HomeCard contents={mainContents?.channelRuleInfo} />
+            <HomeCard contents={mainContents?.channelTimeInfo} />
+            <HomeCard
+              contents='대진표 바로가기'
+              onClick={() => router.push(`/contents/${channelLink}/bracket`)}
+            />
+            <HomeCard contents={mainContents?.channelPrizeInfo} />
+          </HomeCardWrapper>
+          {channelPermission === 0 && (
+            <ModifyButton onClick={() => setIsModify(true)}>내용 수정</ModifyButton>
+          )}
+        </>
+      )}
+    </Container>
+  );
+};
+
+export default Main;
+
+const Container = styled.div`
+  padding: 5%;
+`;
+
+const Title = styled.div`
+  padding-top: 10rem;
+  font-size: 2.5rem;
+  font-weight: bold;
+`;
+
+const SubTitle = styled.div`
+  font-size: 1.5rem;
+  padding: 5rem 0 5rem;
+`;
+
+const HomeCardWrapper = styled.div`
+  display: flex;
+  column-gap: 2rem;
+`;
+
+const ModifyButton = styled.button`
+  font-size: 2rem;
+  color: white;
+  position: fixed;
+  bottom: 3rem;
+  right: 5rem;
+  border: none;
+  padding: 1rem;
+  border-radius: 1rem;
+  background-color: #0067a3;
+
+  &: hover {
+    cursor: pointer;
+  }
+`;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 
 const fetchNotice = async (board: string) => {
+  if (!board) return;
   const res = await authAPI<Array<MainPageNoticeData>>({
     method: 'get',
     url: `/api/notice/${board}`,


### PR DESCRIPTION
## 🤠 개요

- closes: #229 
- 채널 별 메인 홈 화면 추가
- 관리자는 홈 화면의 내용을 수정할 수 있는 기능 추가
- 새로 고침 시 또는 선택된 보드가 없을 시 기본적으로 홈이 선택되도록 수정
<!--
- 이슈번호
- 한줄 설명
- closes: #(이슈번호 입력해주세요)
  -->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
<img width="1840" alt="Screenshot 2023-11-21 at 1 29 32 PM" src="https://github.com/TheUpperPart/leaguehub-frontend/assets/71641127/59f5246c-5266-4b97-8f1e-b7700ec51a28">
<img width="1840" alt="Screenshot 2023-11-21 at 1 29 37 PM" src="https://github.com/TheUpperPart/leaguehub-frontend/assets/71641127/64091f26-6a88-4227-8ea6-10b58c3a196f">
