### PR TITLE
Design: 대회 참여자 모달창 디자인 어두운색 <-> 밝은색 변경

### DIFF
--- a/src/components/Modal/ParticipantLists/index.tsx
+++ b/src/components/Modal/ParticipantLists/index.tsx
@@ -57,8 +57,8 @@ const ParticipantList = ({ leagueTitle }: ParticipantListProps) => {
 export default ParticipantList;
 
 const Container = styled.div`
-  background-color: #202b37;
-  color: white;
+  background-color: #white;
+  color: black;
   border-radius: 2rem;
   margin: 0 auto;
   width: 60rem;
@@ -82,5 +82,5 @@ const MenuList = styled.li<{ isSelected: boolean }>`
     cursor: pointer;
   }
 
-  ${({ isSelected }) => isSelected && 'border-bottom: 2px solid white'};
+  ${({ isSelected }) => isSelected && 'border-bottom: 2px solid black'};
 `;


### PR DESCRIPTION
## 🤠 개요

- closes: #231 
- 대회 참여자 모달창 디자인 어두운색 <-> 밝은색 변경했어요
<!--
- 이슈번호
- 한줄 설명
- closes: #(이슈번호 입력해주세요)
  -->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
<img width="1840" alt="image" src="https://github.com/TheUpperPart/leaguehub-frontend/assets/71641127/32a4cd84-5905-4583-9375-8e39e9c6b7c2">
