### PR TITLE
Fix: 게임 아이디와 태그번호를 구분해서 입력하도록 수정

### DIFF
--- a/src/components/Modal/JoinLeague/JoinLeague.tsx
+++ b/src/components/Modal/JoinLeague/JoinLeague.tsx
@@ -19,26 +19,21 @@ const JoinLeague = ({ onClose, channelLink }: JoinLeagueProps) => {
   const { profile } = useProfile();
   const userNameRef = useRef<HTMLInputElement>(null);
   const gameIdRef = useRef<HTMLInputElement>(null);
-
-  function validateFormat(gameId: string) {
-    const regex = /^[^#]+#\d+$/;
-    console.log(gameId);
-    return regex.test(gameId);
-  }
+  const gameTagRef = useRef<HTMLInputElement>(null);
 
   const submitGameId: MouseEventHandler<HTMLElement> = async () => {
     const gameIdVal = gameIdRef.current?.value;
-    if (!gameIdVal || gameIdVal.length < 2) {
+    const gameTagVal = gameTagRef.current?.value;
+
+    if (!gameIdVal || !gameTagVal || gameIdVal.length < 2 || gameTagVal.length < 2) {
+      alert('아이디와 태그번호를 입력해주세요');
       return;
     }
 
-    if (!validateFormat(gameIdVal)) {
-      alert("'게임아이디#태그번호' 와 같은 형식으로 검색해주세요");
-      return;
-    }
+    const concatGameId = gameIdVal + '#' + gameTagVal;
 
     const userTier: string = (
-      await authAPI.get(SERVER_URL + '/api/participant/stat?gameid=' + gameIdVal)
+      await authAPI.get(SERVER_URL + '/api/participant/stat?gameid=' + concatGameId)
     ).data.tier;
     setTier(userTier);
     setGameId(gameIdVal);
@@ -120,7 +115,16 @@ const JoinLeague = ({ onClose, channelLink }: JoinLeagueProps) => {
         <FlexWrapper>
           <InputButton>
             <Input type='text' placeholder='게임 아이디' ref={gameIdRef} />
-            <Button onClick={submitGameId}>입력</Button>
+            <div
+              css={css`
+                margin-top: 0.5rem;
+                width: 100%;
+                position: relative;
+              `}
+            >
+              #<Input type='text' placeholder='게임 태그 번호' ref={gameTagRef} />
+              <Button onClick={submitGameId}>입력</Button>
+            </div>
           </InputButton>
         </FlexWrapper>
       </Wrapper>
@@ -189,7 +193,7 @@ const Input = styled.input`
   height: 4rem;
   border: none;
   border-radius: 0.6rem;
-  padding: 0.6rem;
+  padding: 0.6rem 5rem 0.6rem 0.6rem;
 `;
 
 const Button = styled.button`
@@ -201,7 +205,7 @@ const Button = styled.button`
   border: none;
   color: white;
   border-radius: 0.6rem;
-  right: 3.2rem;
+  right: 2.5rem;
   top: 0.5rem;
 
   &:hover {


### PR DESCRIPTION
## 🤠 개요

- closes: #233 
- 게임 아이디와 태그번호를 한 번에 입력하는게 아닌 따로 입력하여 한 번에 서버에 요청 보내도록 수정했어요
<!--
- 이슈번호
- 한줄 설명
- closes: #(이슈번호 입력해주세요)
  -->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
<img width="1840" alt="image" src="https://github.com/TheUpperPart/leaguehub-frontend/assets/71641127/eaa26eb5-0945-4dec-85a0-f085969d734f">
