### PR TITLE
Fix/#221 admin 페이지 변경이 되지않는 문제 수정

### DIFF
--- a/src/components/RoundAlarm/RoundAlarmBody.tsx
+++ b/src/components/RoundAlarm/RoundAlarmBody.tsx
@@ -4,13 +4,14 @@ import styled from '@emotion/styled';
 import { BracketContents } from '@type/bracket';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
+import { CallAdmin } from '@type/admin';
 
 interface Props {
   curRound: number;
-  havingAlarm: boolean;
+  alramInfo: CallAdmin | undefined;
 }
 
-const RoundAlarmBody = ({ curRound, havingAlarm }: Props) => {
+const RoundAlarmBody = ({ curRound, alramInfo }: Props) => {
   const router = useRouter();
 
   const [roundInfo, setRoundInfo] = useState<BracketContents>();
@@ -39,15 +40,23 @@ const RoundAlarmBody = ({ curRound, havingAlarm }: Props) => {
     router.push(`/contents/${router.query.channelLink as string}/checkIn/${matchId}`);
   };
 
+  const isMySelfAlarm = () => {
+    return curRound === alramInfo?.matchRound;
+  };
+
+  console.log(roundInfo);
+
   return (
     <Ground>
       {roundInfo?.matchInfoDtoList.map((match) => {
         return (
           <GroupContainer key={match.matchId} onClick={() => moveToCheckIn(match.matchId)}>
             <GroupTitle>{match.matchName}</GroupTitle>
-            <Icon kind='shortcut' size={25} />
+            <AlarmContainer>
+              <Icon kind='shortcut' size={25} />
 
-            {(match.alarm || havingAlarm) && <AlarmCircle />}
+              {(match.alarm || isMySelfAlarm()) && <AlarmCircle />}
+            </AlarmContainer>
           </GroupContainer>
         );
       })}
@@ -57,14 +66,21 @@ const RoundAlarmBody = ({ curRound, havingAlarm }: Props) => {
 
 const Ground = styled.div`
   margin: 2rem 0;
+  display: grid;
+  grid-template-columns: repeat(4, 15rem);
+  column-gap: 2rem;
+  row-gap: 2rem;
 `;
 
 const GroupContainer = styled.div`
   width: 15rem;
-  height: 4rem;
+  height: 7rem;
   display: flex;
   align-items: center;
+
+  background-color: #f3f3f3;
   border: 0.2rem solid #132043;
+  border-radius: 3rem;
 
   justify-content: space-around;
 
@@ -75,6 +91,14 @@ const GroupContainer = styled.div`
 
 const GroupTitle = styled.div`
   font-size: 2rem;
+  line-height: 2rem;
+  display: flex;
+  align-items: center;
+`;
+
+const AlarmContainer = styled.div`
+  display: flex;
+  align-items: center;
 `;
 
 const AlarmCircle = styled.div`

--- a/src/components/RoundAlarm/RoundAlarmBody.tsx
+++ b/src/components/RoundAlarm/RoundAlarmBody.tsx
@@ -28,7 +28,7 @@ const RoundAlarmBody = ({ curRound, havingAlarm }: Props) => {
     };
 
     getRoundInfo();
-  }, []);
+  }, [router.query.channelLink as string]);
 
   const moveToCheckIn = (matchId: number) => {
     authAPI({

--- a/src/pages/contents/[channelLink]/admin.tsx
+++ b/src/pages/contents/[channelLink]/admin.tsx
@@ -52,10 +52,6 @@ const Admin = ({ role }: Props) => {
     router.push('/');
   }
 
-  const isMySelfAlarm = () => {
-    return curRound === alramInfo?.matchRound;
-  };
-
   useEffect(() => {
     const tmpClient = connectToStomp();
     tmpClient.activate();
@@ -120,11 +116,7 @@ const Admin = ({ role }: Props) => {
           })}
         </RoundList>
       </BracketContainer>
-      {curRound && (
-        <div>
-          <RoundAlarmBody curRound={curRound} havingAlarm={isMySelfAlarm()} />
-        </div>
-      )}
+      {curRound && <RoundAlarmBody curRound={curRound} alramInfo={alramInfo} />}
     </Container>
   );
 };
@@ -133,6 +125,20 @@ export default Admin;
 
 const Container = styled.div`
   margin-left: 2rem;
+  height: calc(100vh - 5.5rem);
+  overflow-y: auto;
+
+  ::-webkit-scrollbar {
+    width: 1rem;
+  }
+  ::-webkit-scrollbar-thumb {
+    background-color: #202b37;
+    border-radius: 1rem;
+  }
+  ::-webkit-scrollbar-track {
+    background-color: #344051;
+    border-radius: 1rem;
+  }
 `;
 
 const Header = styled.div`

--- a/src/pages/contents/[channelLink]/admin.tsx
+++ b/src/pages/contents/[channelLink]/admin.tsx
@@ -41,7 +41,7 @@ const Admin = ({ role }: Props) => {
   const { openModal, closeModal } = useModals();
 
   const { data, isSuccess } = useQuery({
-    queryKey: ['roundInfos'],
+    queryKey: ['adminRoundList', router.query.channelLink as string],
     queryFn: () => {
       setCurRound(1);
       return fetchRoundInfo(router.query.channelLink as string);
@@ -76,10 +76,7 @@ const Admin = ({ role }: Props) => {
       if (checkInSubscription) checkInSubscription.unsubscribe();
       client.deactivate();
     };
-  }, []);
-
-  if (isSuccess) {
-  }
+  }, [router.query.channelLink as string]);
 
   return (
     <Container>


### PR DESCRIPTION
## 🤠 개요

- closes: #221 
<!--
- 이슈번호
- 한줄 설명
- closes: #(이슈번호 입력해주세요)
  -->

query만 변경되면 리렌더링이 되지 않아 useEffect 의존성 배열에 query를 추가했어요.

## 💫 설명
query만 변경되면 리렌더링이 되지 않아 useEffect 의존성 배열에 query를 추가했어요.

스크롤할 수 있도록 스크롤 css 추가
<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)

![dddd](https://github.com/TheUpperPart/leaguehub-frontend/assets/100738049/59019681-b8c9-4fae-a78e-ce9c9b7783b5)

