### PR TITLE
Fix(JoinLeague): 게임 아이디 조회 시 파라미터 형식 변경

### DIFF
--- a/src/components/Modal/JoinLeague/JoinLeague.tsx
+++ b/src/components/Modal/JoinLeague/JoinLeague.tsx
@@ -30,10 +30,8 @@ const JoinLeague = ({ onClose, channelLink }: JoinLeagueProps) => {
       return;
     }
 
-    const concatGameId = gameIdVal + '#' + gameTagVal;
-
     const userTier: string = (
-      await authAPI.get(SERVER_URL + '/api/participant/stat?gameid=' + concatGameId)
+      await authAPI.get(SERVER_URL + `/api/participant/stat/${gameIdVal}/${gameTagVal}`)
     ).data.tier;
     setTier(userTier);
     setGameId(gameIdVal);


### PR DESCRIPTION
## 🤠 개요

- closes: #240
- #은 전송이 불가능하기에 gameId/gameTag 순서로 전송하도록 수정했어요
- 게임 아이디 조회 시 파라미터 형식 변경했어요
<!--
- 이슈번호
- 한줄 설명
- closes: #(이슈번호 입력해주세요)
  -->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
