### PR TITLE
Fix/#242: 채널 참여가 안되는 문제 & 관리자가 메인 화면 수정 못하는 문제 수정

### DIFF
--- a/src/components/Modal/JoinLeague/JoinLeague.tsx
+++ b/src/components/Modal/JoinLeague/JoinLeague.tsx
@@ -34,7 +34,7 @@ const JoinLeague = ({ onClose, channelLink }: JoinLeagueProps) => {
       await authAPI.get(SERVER_URL + `/api/participant/stat/${gameIdVal}/${gameTagVal}`)
     ).data.tier;
     setTier(userTier);
-    setGameId(gameIdVal);
+    setGameId(gameIdVal + '#' + gameTagVal);
   };
 
   const nicknameHandler: MouseEventHandler<HTMLElement | SVGElement> = () => {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,4 +1,4 @@
-let SERVER_URL = 'http://leaguehub.co.kr';
+let SERVER_URL = 'http://leaguehub.co.kr:8080';
 const SOCKET_URL = 'ws://leaguehub.co.kr/ws/websocket';
 
 if (process.env.NODE_ENV === 'development') {

--- a/src/pages/contents/[channelLink]/main.tsx
+++ b/src/pages/contents/[channelLink]/main.tsx
@@ -1,7 +1,6 @@
 import authAPI from '@apis/authAPI';
 import HomeCard from '@components/Card/HomeCard';
 import MainContentModify from '@components/Content/MainContentModify';
-import Loading from '@components/Loading/Loading';
 import styled from '@emotion/styled';
 import useChannels from '@hooks/useChannels';
 import { useQuery } from '@tanstack/react-query';
@@ -37,7 +36,7 @@ const Main = () => {
   const { channelPermission } = useChannels();
   const channelLink = router.query.channelLink;
 
-  const { data, isLoading, isSuccess } = useQuery<MainContent | undefined>(
+  const { data, isSuccess } = useQuery<MainContent | undefined>(
     ['getMainContents', channelLink],
     () => {
       return fetchData(channelLink as string);
@@ -48,14 +47,14 @@ const Main = () => {
     if (isSuccess && data) setMainContents(data);
   }, [isSuccess]);
 
-  if (isLoading) {
-    return <Loading />;
-  }
-
   const handleContentUpdate = async (updatedContent: MainContent) => {
     if (!channelLink) return;
 
-    const res = await authAPI({ method: 'post', url: `/api/channel/${channelLink}/main` });
+    const res = await authAPI({
+      method: 'post',
+      url: `/api/channel/${channelLink}/main`,
+      data: updatedContent,
+    });
     if (res.status !== 200) return router.push('/');
 
     setMainContents(updatedContent);


### PR DESCRIPTION
## 🤠 개요

- closes: #242 
- 유저가 채널 참여 시 게임 아이디와 태그번호를 서버에 전송하도록 하여 참여 안되는 문제를 해결했어요
- 관리자가 메인 화면 수정 시 데이터를 보내지 않아 발생하던 문제를 해결했어요
<!--
- 이슈번호
- 한줄 설명
- closes: #(이슈번호 입력해주세요)
  -->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
