### PR TITLE
Design/#245 관리자 페이지 디자인 변경

### DIFF
--- a/src/components/Modal/ModifyChannel/ModifyBracket.tsx
+++ b/src/components/Modal/ModifyChannel/ModifyBracket.tsx
@@ -45,18 +45,21 @@ const Container = styled.div`
   position: relative;
 
   width: 40rem;
-  height: 60rem;
+  height: 40rem;
   display: flex;
 
-  background-color: #344051;
+  border-radius: 4rem;
+
+  background-color: #f2f2f2;
 `;
 
 const Content = styled.div`
-  margin: 2rem 1rem;
+  width: 95%;
+  margin: 0 auto;
 `;
 
 const Header = styled.div`
-  color: white;
+  color: #020202;
 
   font-size: 2rem;
 
@@ -80,7 +83,7 @@ const HeaderList = styled.button<{ isSelected: boolean }>`
     `}
 
   background-color: inherit;
-  color: white;
+  color: #020202;
   font-size: 2rem;
   font-weight: 900;
 

--- a/src/components/Modal/ModifyChannel/ModifyChannel.tsx
+++ b/src/components/Modal/ModifyChannel/ModifyChannel.tsx
@@ -21,26 +21,27 @@ const fetchChannelInfo = async (channelLink: string) => {
 const ModifyChannel = ({ channelLink, onClose }: ModifyChannelProps) => {
   const [selectedMenu, setSelectedMenu] = useState<MenuList>('basicInfo');
 
-  const handleSelectedMenu = (menu: MenuList) => {
-    setSelectedMenu(menu);
-  };
-
   const { data, isSuccess, isError, isLoading } = useQuery(['channelInfo', channelLink], () => {
     return fetchChannelInfo(channelLink);
   });
 
   return (
     <Container>
-      <Sidebar>
-        <SidebarContent onClick={() => handleSelectedMenu('basicInfo')}>
-          대회 기본 정보 수정
-        </SidebarContent>
-
-        <SidebarContent onClick={() => handleSelectedMenu('bracketInfo')}>
-          대진표 수정
-        </SidebarContent>
-      </Sidebar>
-      <MainContent>
+      <Content>
+        <Header>
+          <HeaderList
+            isSelected={selectedMenu === 'basicInfo'}
+            onClick={() => setSelectedMenu('basicInfo')}
+          >
+            대회 정보 수정
+          </HeaderList>
+          <HeaderList
+            isSelected={selectedMenu === 'bracketInfo'}
+            onClick={() => setSelectedMenu('bracketInfo')}
+          >
+            대진표 수정
+          </HeaderList>
+        </Header>
         {selectedMenu === 'basicInfo' && (
           <BasicInfoChannel
             channelLink={channelLink}
@@ -49,10 +50,10 @@ const ModifyChannel = ({ channelLink, onClose }: ModifyChannelProps) => {
           />
         )}
         {selectedMenu === 'bracketInfo' && <BracketInfoChannel />}
-      </MainContent>
-      <CloseButtonContainer>
-        <Icon kind='cancel' size={40} onClick={() => onClose()} />
-      </CloseButtonContainer>
+        <CloseButtonContainer>
+          <Icon kind='cancel' size={40} onClick={() => onClose()} />
+        </CloseButtonContainer>
+      </Content>
     </Container>
   );
 };
@@ -60,38 +61,52 @@ const ModifyChannel = ({ channelLink, onClose }: ModifyChannelProps) => {
 export default ModifyChannel;
 
 const Container = styled.div`
-  width: 80rem;
-  height: 60rem;
-  background-color: white;
-
-  display: flex;
   position: relative;
+
+  width: 40rem;
+  height: 40rem;
+  display: flex;
+
+  border-radius: 4rem;
+
+  background-color: #f2f2f2;
 `;
 
-const Sidebar = styled.div`
-  width: 30rem;
-  background-color: #141c24;
-`;
-
-const SidebarContent = styled.div`
-  width: 80%;
-  height: 5rem;
+const Content = styled.div`
+  width: 95%;
   margin: 0 auto;
-  color: white;
+`;
+
+const Header = styled.div`
+  color: #020202;
 
   font-size: 2rem;
-  font-weight: 900;
+
+  height: 5rem;
 
   display: flex;
   align-items: center;
-
-  cursor: pointer;
+  column-gap: 2rem;
 `;
 
-const MainContent = styled.div`
-  width: calc(100vw - 30rem);
+const HeaderList = styled.button<{ isSelected: boolean }>`
+  margin: 0;
+  padding: 0;
+  border: none;
 
-  background-color: #202b37;
+  ${(prop) =>
+    prop.isSelected &&
+    `
+      text-decoration:underline;
+      text-underline-position: under;
+    `}
+
+  background-color: inherit;
+  color: #020202;
+  font-size: 2rem;
+  font-weight: 900;
+
+  cursor: pointer;
 `;
 
 const CloseButtonContainer = styled.div`

--- a/src/components/ModifyChannel/AssignBracket.tsx
+++ b/src/components/ModifyChannel/AssignBracket.tsx
@@ -13,8 +13,6 @@ const fetchAllBracket = async (channelLink: string) => {
     url: `/api/match/${channelLink}`,
   });
 
-  console.log(res);
-
   return res.data;
 };
 
@@ -53,7 +51,7 @@ const AssignBracket = () => {
             {round === data.liveRound && <BracketButton status='DONE'>배정 완료</BracketButton>}
             {round === data.liveRound + 1 && (
               <BracketButton status='READY' onClick={() => fetchSetBracket(round)}>
-                배정하기
+                배정 하기
               </BracketButton>
             )}
             {round > data.liveRound + 1 && <BracketButton status='BAN'>배정 불가</BracketButton>}
@@ -79,8 +77,9 @@ const Bracket = styled.div`
 
 const BracketHeader = styled.div`
   font-size: 1.6rem;
-
-  color: white;
+  font-weight: 700;
+  width: 8rem;
+  color: #020202;
 `;
 
 const BracketButton = styled.button<{ status: bracketStatus }>`
@@ -92,6 +91,8 @@ const BracketButton = styled.button<{ status: bracketStatus }>`
 
   font-size: 1.6rem;
   color: white;
+
+  border-radius: 2rem;
 
   ${(prop) =>
     prop.status === 'DONE' &&

--- a/src/components/ModifyChannel/BasicInfoChannel.tsx
+++ b/src/components/ModifyChannel/BasicInfoChannel.tsx
@@ -37,7 +37,6 @@ const BasicInfoChannel = ({ channelLink, leagueTitle, maxPlayer }: BasicInfoChan
 
   return (
     <Container>
-      <Header>리그 수정하기</Header>
       <Content>
         <Wrapper>
           <FlexWrapper>리그 제목</FlexWrapper>
@@ -63,9 +62,7 @@ const BasicInfoChannel = ({ channelLink, leagueTitle, maxPlayer }: BasicInfoChan
         </Wrapper>
       </Content>
 
-      <ButtonWrapper>
-        <SubmitButton onClick={onClickSubmit}>수정하기</SubmitButton>
-      </ButtonWrapper>
+      <SubmitButton onClick={onClickSubmit}>수정하기</SubmitButton>
     </Container>
   );
 };
@@ -73,14 +70,7 @@ const BasicInfoChannel = ({ channelLink, leagueTitle, maxPlayer }: BasicInfoChan
 export default BasicInfoChannel;
 
 const Container = styled.div`
-  margin: 2rem 4rem;
-`;
-const Header = styled.div`
-  text-align: left;
-
-  font-size: 3rem;
-  font-weight: 900;
-  color: white;
+  width: 40rem;
 `;
 
 const Content = styled.div``;
@@ -95,9 +85,7 @@ const Wrapper = styled.div`
   min-height: 7rem;
 `;
 
-const FlexWrapper = styled.div`
-  color: white;
-`;
+const FlexWrapper = styled.div``;
 
 const ButtonWrapper = styled.div`
   display: flex;
@@ -117,18 +105,23 @@ const Input = styled.input`
 `;
 
 const SubmitButton = styled.button`
-  width: 10rem;
-  height: 6rem;
-  background-color: #344051;
+  position: absolute;
+  bottom: 2rem;
+  right: -4rem;
+  width: 8rem;
+  height: 4rem;
+  background-color: #ffffff;
   border: none;
   border-radius: 0.5rem;
-  color: white;
+  color: #020202;
   margin: 0 6rem 0 6rem;
   &:hover {
     cursor: pointer;
+    background-color: #ff4655;
+    color: #ffffff;
   }
   &:disabled {
-    background-color: #d3d3d3;
+    background-color: #ffffff;
     cursor: not-allowed;
   }
 `;

--- a/src/components/ModifyChannel/BracketInfoChannel.tsx
+++ b/src/components/ModifyChannel/BracketInfoChannel.tsx
@@ -69,7 +69,6 @@ const BracketInfoChannel = () => {
 
   return (
     <Container>
-      <Header>라운드 수정</Header>
       <Content>
         {isLoading && <div>로딩 중</div>}
         {isError && <div>Error</div>}
@@ -90,9 +89,7 @@ const BracketInfoChannel = () => {
             </RoundInfo>
           );
         })}
-        <ButtonWrapper>
-          <ModifyButton onClick={updateRoundMatchCount}>수정완료</ModifyButton>
-        </ButtonWrapper>
+        <ModifyButton onClick={updateRoundMatchCount}>수정 하기</ModifyButton>
       </Content>
     </Container>
   );
@@ -101,18 +98,15 @@ const BracketInfoChannel = () => {
 export default BracketInfoChannel;
 
 const Container = styled.div`
-  margin: 2rem 4rem;
+  color: #020202;
 `;
 
-const Header = styled.div`
-  text-align: left;
-
-  font-size: 3rem;
-  font-weight: 900;
-  color: white;
+const Content = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  width: 95%;
+  margin: 0 auto;
 `;
-
-const Content = styled.div``;
 
 const RoundInfo = styled.div`
   height: 7rem;
@@ -122,26 +116,33 @@ const RoundInfo = styled.div`
 `;
 
 const RoundInfoHeader = styled.div`
-  font-size: 2rem;
-  color: white;
+  font-size: 1.6rem;
+  width: 10rem;
 `;
 
 const ButtonWrapper = styled.div`
   display: flex;
   align-items: center;
-  justify-content: flex-end;
 `;
 
 const ModifyButton = styled.button`
-  width: 10rem;
-  height: 6rem;
-  background-color: #344051;
+  position: absolute;
+  bottom: 2rem;
+  right: -4rem;
+  width: 8rem;
+  height: 4rem;
+  background-color: #ffffff;
   border: none;
   border-radius: 0.5rem;
-  color: white;
+  color: #020202;
   margin: 0 6rem 0 6rem;
-
-  cursor: pointer;
-
-  font-size: 1.8rem;
+  &:hover {
+    cursor: pointer;
+    background-color: #ff4655;
+    color: #ffffff;
+  }
+  &:disabled {
+    background-color: #ffffff;
+    cursor: not-allowed;
+  }
 `;

--- a/src/components/ModifyChannel/StartMatch.tsx
+++ b/src/components/ModifyChannel/StartMatch.tsx
@@ -19,7 +19,7 @@ const StartMatch = () => {
   const handleStartMatch = async () => {
     if (window.confirm('대회를 시작하시겠습니까?\n시작한 이후에는 중지할 수 없습니다')) {
       try {
-        const res = fetchStartBracket();
+        const res = await fetchStartBracket();
         window.alert('대회가 시작되었습니다!\nRound 1 배정을 해주세요!');
       } catch (error) {
         if (error instanceof AxiosError) {
@@ -31,15 +31,33 @@ const StartMatch = () => {
 
   return (
     <Container>
-      <Button width={20} height={5} onClick={handleStartMatch}>
-        대회 시작
-      </Button>
+      <StartButton onClick={handleStartMatch}>대회 시작</StartButton>
+      <Text>대회가 시작된 후 취소할 수 없습니다!</Text>
     </Container>
   );
 };
 
 const Container = styled.div`
-  margin: 2rem 1rem;
+  width: 95%;
+  margin: 0 auto;
+  text-align: left;
+`;
+
+const Text = styled.div`
+  margin: 2rem 0;
+  font-size: 1.6rem;
+  color: #020202;
+`;
+const StartButton = styled.button`
+  background-color: #1aacac;
+
+  width: 12rem;
+  height: 4rem;
+
+  border-radius: 4rem;
+  border: none;
+
+  color: #f2f2f2;
 `;
 
 export default StartMatch;

--- a/src/components/RoundAlarm/RoundAlarmBody.tsx
+++ b/src/components/RoundAlarm/RoundAlarmBody.tsx
@@ -74,7 +74,7 @@ const Ground = styled.div`
 
 const GroupContainer = styled.div`
   width: 15rem;
-  height: 7rem;
+  height: 5rem;
   display: flex;
   align-items: center;
 

--- a/src/components/RoundAlarm/RoundAlarmHeader.tsx
+++ b/src/components/RoundAlarm/RoundAlarmHeader.tsx
@@ -27,6 +27,8 @@ const Button = styled.button<{ status: bracketStatus }>`
   font-size: 1.6rem;
   color: white;
 
+  border-radius: 2rem;
+
   ${(prop) =>
     prop.status === 'PAST' &&
     `

--- a/src/pages/contents/[channelLink]/admin.tsx
+++ b/src/pages/contents/[channelLink]/admin.tsx
@@ -78,9 +78,7 @@ const Admin = ({ role }: Props) => {
     <Container>
       <Header>대회 설정</Header>
       <BracketContainer>
-        <Button
-          width={20}
-          height={6}
+        <AdminButton
           onClick={() =>
             openModal(Modal, {
               onClose: () => closeModal(Modal),
@@ -89,10 +87,8 @@ const Admin = ({ role }: Props) => {
           }
         >
           대회 관리하기
-        </Button>
-        <Button
-          width={20}
-          height={6}
+        </AdminButton>
+        <AdminButton
           onClick={() =>
             openModal(Modal, {
               onClose: () => closeModal(Modal),
@@ -106,7 +102,7 @@ const Admin = ({ role }: Props) => {
           }
         >
           채널 정보 수정하기
-        </Button>
+        </AdminButton>
       </BracketContainer>
       <Header>대회 알림</Header>
       <BracketContainer>
@@ -145,6 +141,20 @@ const Header = styled.div`
   font-size: 3rem;
   font-weight: 900;
   margin: 2rem 0;
+`;
+
+const AdminButton = styled.button`
+  background-color: #f2f2f2;
+  width: 15rem;
+  height: 6rem;
+
+  border-radius: 2rem;
+
+  cursor: pointer;
+  &:hover {
+    background-color: #ff4655;
+    color: #f2f2f2;
+  }
 `;
 
 const BracketContainer = styled.div`


### PR DESCRIPTION
## 🤠 개요

- closes: #245
- 관리자 페이지의 전반적인 디자인을 변경했어요.

## 💫 설명

관리자 페이지의 전반적인 디자인을 수정했어요.
- 채널 정보 수정 모달 디자인 변경
- 대진표 관련 모달 디자인 변경

## 📷 스크린샷 (Optional)
- 전
<img width="449" alt="Screenshot 2023-11-21 at 10 40 51 PM" src="https://github.com/TheUpperPart/leaguehub-frontend/assets/100738049/174deb23-64d6-4bba-8812-98d24f0d3007">

- 후
<img width="451" alt="Screenshot 2023-11-21 at 10 40 44 PM" src="https://github.com/TheUpperPart/leaguehub-frontend/assets/100738049/a797a548-c261-4b48-b20a-286540e3833d">


