### PR TITLE
Design/#247 마이페이지 및 헤더 드롭다운 디자인 변경

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -183,9 +183,9 @@ const DropDown = styled.ul<{ click: boolean }>`
   width: 10rem;
 
   top: 5.5rem;
-  right: 0rem;
+  right: 2.5rem;
 
-  color: black;
+  color: #020202;
 `;
 
 const DropList = styled.li`
@@ -200,5 +200,5 @@ const DropList = styled.li`
   color: #000000;
 
   height: 4rem;
-  border: 1px solid black;
+  border: 1px solid #020202;
 `;

--- a/src/pages/mypage.tsx
+++ b/src/pages/mypage.tsx
@@ -147,6 +147,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
 
 const Container = styled.div`
   margin: 0 auto;
+  color: #020202;
 `;
 
 const Wrapper = styled.div`
@@ -157,13 +158,14 @@ const Wrapper = styled.div`
 `;
 
 const Contents = styled.div`
-  width: 60rem;
-  background-color: #edede9;
+  width: 50rem;
+  background-color: #f2f2f2;
   border-radius: 2rem;
 `;
 
 const Title = styled.h2`
   text-align: center;
+  margin: 2rem 0;
 `;
 
 const Content = styled.div`


### PR DESCRIPTION
## 🤠 개요

- closes: #247 
- 마이페이지 디자인과 헤더 드롭다운을 디자인을 다시했어요.

## 💫 설명
헤더 드롭다운 위치가 이상해서 디자인을 변경했고 마이페이지 또한 너무 커서 크기를 줄였어요

## 📷 스크린샷 (Optional)
