### PR TITLE
Fix: noticeInfo가 있을때만 보여주도록 수정

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -44,7 +44,7 @@ export default function Home() {
                   {notice.noticeTitle}
                 </ItemLink>
               </ItemHeader>
-              <span>{notice.noticeInfo.length ? `- ${notice.noticeInfo}` : ''}</span>
+              {notice.noticeInfo && <span>`- ${notice.noticeInfo}`</span>}
             </Item>
           );
         })}


### PR DESCRIPTION
## 🤠 개요
noticeInfo가 있을때만 보여주도록 수정했어요!
- closes: #256 
<!--
- 이슈번호
- 한줄 설명
- closes: #(이슈번호 입력해주세요)
  -->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
