### PR TITLE
Feat: 에메랄드 티어 추가 및 handleTier 로직 변경

### DIFF
--- a/src/components/MakeChannel/CustomRule.tsx
+++ b/src/components/MakeChannel/CustomRule.tsx
@@ -17,7 +17,7 @@ const CustomRule = ({ state }: Props) => {
     const tierToNum = Number(e.target.value);
 
     setTier(tierToNum);
-    if (tierToNum >= 2400) {
+    if (tierToNum >= 2800) {
       setGrade(0);
     }
   };
@@ -43,7 +43,7 @@ const CustomRule = ({ state }: Props) => {
         })}
       </SelectBox>
 
-      {tier < 2400 && (
+      {tier < 2800 && (
         <SelectBox onChange={handleGrade}>
           <option value='0'>4 티어</option>
           <option value='100'>3 티어</option>

--- a/src/constants/TFT.ts
+++ b/src/constants/TFT.ts
@@ -26,20 +26,24 @@ export const TFTTier: TFTTiers = {
     displayName: '플래티넘',
     defaultValue: 1600,
   },
+  Emerald: {
+    displayName: '에메랄드',
+    defaultValue: 2000,
+  },
   Diamond: {
     displayName: '다이아몬드',
-    defaultValue: 2000,
+    defaultValue: 2400,
   },
   Master: {
     displayName: '마스터',
-    defaultValue: 2400,
+    defaultValue: 2800,
   },
   GrandMaster: {
     displayName: '그랜드 마스터',
-    defaultValue: 2800,
+    defaultValue: 3200,
   },
   Challenger: {
     displayName: '챌린저',
-    defaultValue: 3200,
+    defaultValue: 3600,
   },
 };


### PR DESCRIPTION
## 🤠 개요
에메랄드 티어가 추가되어서 추가했어요.

또, 2400점 이상이면 티어 선택창을 안보여줬는데 에메랄드가 생기면서 2800으로 변경했어요.

- closes: #258
<!--
- 이슈번호
- 한줄 설명
- closes: #(이슈번호 입력해주세요)
  -->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
