### PR TITLE
Feat/#274 SSR에서 토큰 탑재 자동화 및 마이페이지 리팩토링

### DIFF
--- a/src/apis/mypage.ts
+++ b/src/apis/mypage.ts
@@ -16,13 +16,13 @@ export const sendEmailVerification = async (email: string) => {
   });
 };
 
-export const fetchMy = async () => {
+export const fetchMyPageWithSSR = async () => {
   const res = await authAPI<MyPage>({
     method: 'get',
     url: '/api/member/mypage',
   });
 
-  return res;
+  return res.data;
 };
 
 export const fetchProfile = async () => {

--- a/src/constants/queryManagement.ts
+++ b/src/constants/queryManagement.ts
@@ -1,0 +1,17 @@
+import { fetchMyPageWithSSR, sendEmailVerification } from '@apis/mypage';
+
+const QUERY_MANAGEMENT = {
+  mypage: {
+    queryKey: 'mypage',
+    queryFn: fetchMyPageWithSSR,
+  },
+};
+
+const MUTATION_MANAGEMENT = {
+  email: {
+    mutateKey: 'sendEmail',
+    mutateFn: (email: string) => sendEmailVerification(email),
+  },
+};
+
+export { QUERY_MANAGEMENT, MUTATION_MANAGEMENT };

--- a/src/hooks/mutation/useSendEmailMutation.ts
+++ b/src/hooks/mutation/useSendEmailMutation.ts
@@ -1,0 +1,22 @@
+import { MUTATION_MANAGEMENT } from '@constants/queryManagement';
+import useInput from '@hooks/useInput';
+import { useMutation } from '@tanstack/react-query';
+import { useState } from 'react';
+
+const useSendEmailMutation = () => {
+  const [email, setEmail, resetEmail] = useInput('');
+  const [isSendVerifyEmail, setIsSendVerifyEmail] = useState<boolean>(false);
+
+  const { mutate } = useMutation({
+    mutationKey: [MUTATION_MANAGEMENT.email.mutateKey],
+    mutationFn: () => MUTATION_MANAGEMENT.email.mutateFn(email),
+    onMutate: () => {
+      alert('이메일을 보냈습니다.');
+      setIsSendVerifyEmail(true);
+    },
+  });
+
+  return { email, setEmail, resetEmail, isSendVerifyEmail, mutate };
+};
+
+export default useSendEmailMutation;

--- a/src/hooks/query/useMyPageQuery.ts
+++ b/src/hooks/query/useMyPageQuery.ts
@@ -1,0 +1,13 @@
+import { QUERY_MANAGEMENT } from '@constants/queryManagement';
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+const useMyPageQuery = () => {
+  const { data, refetch } = useSuspenseQuery({
+    queryKey: [QUERY_MANAGEMENT.mypage.queryKey],
+    queryFn: QUERY_MANAGEMENT.mypage.queryFn,
+  });
+
+  return { data, refetch };
+};
+
+export default useMyPageQuery;

--- a/src/hooks/useInput.ts
+++ b/src/hooks/useInput.ts
@@ -1,0 +1,22 @@
+import { useState, useCallback } from 'react';
+
+const useInput = (initialValue: string) => {
+  const [inputValue, setInputValue] = useState<string>(initialValue);
+
+  const handleValue = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      const { value } = e.target;
+
+      setInputValue(value);
+    },
+    [],
+  );
+
+  const resetValue = useCallback(() => {
+    setInputValue('');
+  }, []);
+
+  return [inputValue, handleValue, resetValue] as const;
+};
+
+export default useInput;

--- a/src/utils/withAuthentication.tsx
+++ b/src/utils/withAuthentication.tsx
@@ -1,0 +1,25 @@
+import authAPI from '@apis/authAPI';
+import { parse } from 'cookie';
+import { GetServerSidePropsContext } from 'next';
+
+const withAuthServerSideProps = (getServerSidePropsFunction: () => Promise<any>) => {
+  return async (context: GetServerSidePropsContext) => {
+    const cookies = context.req.headers.cookie || '';
+
+    const accessToken = parse(cookies).accessToken;
+
+    if (!accessToken) {
+      throw new Error('401 Unauthorized');
+    }
+
+    authAPI.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;
+
+    const res = await getServerSidePropsFunction();
+
+    authAPI.defaults.headers.common['Authorization'] = '';
+
+    return res;
+  };
+};
+
+export default withAuthServerSideProps;


### PR DESCRIPTION
## 🤠 개요




- closes: #274 
<!--
- 이슈번호
- 한줄 설명
- closes: #(이슈번호 입력해주세요)
  -->
- 마이페이지 리팩토링
- 쿼리 상수 파일
- SSR에서 토큰 탑재 자동화 함수 생성
## 💫 설명
- 마이페이지에 로직을 커스텀훅으로 분리하였어요.

- 마이페이지에서 낙관적 업데이트를 적용해서 이메일 전송이 되기전 전송되었다고 알려줘요

- 또, 쿼리와 뮤테이션을 관리하는 상수 파일을 만들었어요. 앞으로 작성하는 쿼리와 뮤테이션 키와 함수는 해당 파일에 작성해서 불러와주세요!

- useInput 커스텀훅을 만들었어요. 

- SSR에서 헤더에 토큰이 자동적으로 탑재되도록 HOF를 하나 만들었어요.
기존에는 getServerSideProps를 사용하는 페이지마다 토큰을 탑재해야했는데 해당 불편함을 해결했어요.

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
