### PR TITLE
Feat/#285 로그인 확인 미들웨어 작성 및 로그인 페이지 변경

### DIFF
--- a/src/components/Sidebar/ChannelBar/ChannelBar.tsx
+++ b/src/components/Sidebar/ChannelBar/ChannelBar.tsx
@@ -1,10 +1,8 @@
 import { DragDropContext, Droppable, Draggable, DropResult } from '@hello-pangea/dnd';
 import styled from '@emotion/styled';
-import { css } from '@emotion/react';
 
 import SelectChannelType from '@components/Sidebar/ChannelBar/SelectChannelType';
 import ChannelCircle from '@components/Sidebar/ChannelCircle/ChannelCircle';
-import { ChannelCircleProps } from '@type/channelCircle';
 import useChannels from '@hooks/useChannels';
 import Modal from '@components/Modal';
 import Icon from '@components/Icon';
@@ -13,14 +11,10 @@ import useMakeGame from '@hooks/useMakeGame';
 import MainChannelCircle from '../ChannelCircle/MainChannelCircle';
 import { useRouter } from 'next/router';
 
-interface ChannelBarProps {
-  channels: ChannelCircleProps[];
-}
-
-const ChannelBar = ({ channels }: ChannelBarProps) => {
+const ChannelBar = () => {
   const router = useRouter();
 
-  const { dragAndDropChannels } = useChannels();
+  const { channels, dragAndDropChannels } = useChannels();
   const { openModal, closeModal } = useModals();
 
   const { resetState } = useMakeGame();

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -1,83 +1,71 @@
-import { PropsWithChildren, useEffect, useState } from 'react';
+import { PropsWithChildren } from 'react';
 import styled from '@emotion/styled';
 
 import ChannelBar from '@components/Sidebar/ChannelBar/ChannelBar';
 import BoardBar from '@components/Sidebar/BoardBar/BoardBar';
 import GlobalStyle from 'src/styles/GlobalStyle';
 import Header from '@components/Header/Header';
-import useChannels from '@hooks/useChannels';
-import useProfile from '@hooks/useProfile';
-import NoAuthMain from './Main/NoAuthMain';
-import Loading from './Loading/Loading';
+
 import { useRouter } from 'next/router';
+import ChannelsProvider from './providers/ChannelsProvider';
+import ProfileProvider from './providers/ProfileProvider';
+import LastVisitedBoardListsProvider from './providers/LastVisitedBoardListsProvider';
+import MakeGameProvider from './providers/MakeGameProvider';
 
 const Layout = ({ children }: PropsWithChildren) => {
   const router = useRouter();
 
-  const { channels } = useChannels();
-
-  const { status } = useProfile();
-
-  // 요청했을 때만
-  if (status === 'pending') {
+  if (router.pathname.startsWith('/login')) {
     return (
       <>
+        <GlobalStyle />
         <CommonLayout>
-          <GlobalStyle />
-          <Loading />
-        </CommonLayout>
-      </>
-    );
-  }
-
-  if (status === 'error') {
-    return (
-      <>
-        <CommonLayout>
-          <GlobalStyle />
-          <NoAuthMain />
+          <Wrapper>{children}</Wrapper>
         </CommonLayout>
       </>
     );
   }
 
   return (
-    <AuthLayout>
+    <LayoutContainer>
+      <ChannelsProvider>
+        <ProfileProvider>
+          <LastVisitedBoardListsProvider>
+            <MakeGameProvider>
+              <CommonLayout>
+                <SidebarWrapper>
+                  <ChannelBar />
+                </SidebarWrapper>
+                <SidebarWrapper>
+                  <BoardBar />
+                </SidebarWrapper>
+                <Wrapper>
+                  <Header />
+                  <Main>{children}</Main>
+                </Wrapper>
+              </CommonLayout>
+            </MakeGameProvider>
+          </LastVisitedBoardListsProvider>
+        </ProfileProvider>
+      </ChannelsProvider>
       <GlobalStyle />
-      <AuthCommonLayout>
-        <SidebarWrapper>{channels && <ChannelBar channels={channels} />}</SidebarWrapper>
-        <SidebarWrapper>
-          <BoardBar />
-        </SidebarWrapper>
-        <Wrapper>
-          <Header />
-          <Main>{children}</Main>
-        </Wrapper>
-      </AuthCommonLayout>
-    </AuthLayout>
+    </LayoutContainer>
   );
 };
 
-const AuthLayout = styled.div`
+const LayoutContainer = styled.div`
   padding: 2rem;
   background-color: ${({ theme }) => theme.bg};
 `;
 
-const AuthCommonLayout = styled.div`
-  display: flex;
-  height: calc(100vh - 4rem);
-`;
-
 const CommonLayout = styled.div`
   display: flex;
+  height: calc(100vh - 4rem);
 `;
 
 const Wrapper = styled.div`
   width: 100%;
   height: 100%;
-  /* background-image: url('/img/board/main.png');
-  background-size: 100% 100vh;
-  background-repeat: no-repeat; */
 `;
 
 const SidebarWrapper = styled.div`

--- a/src/components/providers/ProfileProvider.tsx
+++ b/src/components/providers/ProfileProvider.tsx
@@ -3,7 +3,6 @@ import { useQuery } from '@tanstack/react-query';
 
 import ProfileContext from '@contexts/ProfileContext';
 import { Profile } from '@type/profile';
-import Cookies from 'js-cookie';
 import { fetchProfile } from '@apis/mypage';
 
 interface ProfileAPI {
@@ -17,8 +16,6 @@ interface ProfileProviderProps {
 
 const ProfileProvider = ({ children }: ProfileProviderProps) => {
   // 유저가 로그인 되어있는지 확인
-
-  const isHaveAccessToken = Cookies.get('accessToken');
 
   const [profile, setProfile] = useState<Profile | null>(null);
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  if (!request.cookies.get('accessToken')) {
+    return NextResponse.redirect(new URL('/login', request.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/', '/mypage', '/contents/:channelLink*'],
+};

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -3,10 +3,6 @@ import { useEffect, useState } from 'react';
 import { HydrationBoundary, QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
-import LastVisitedBoardListsProvider from '@components/providers/LastVisitedBoardListsProvider';
-import ProfileProvider from '@components/providers/ProfileProvider';
-import MakeGameProvider from '@components/providers/MakeGameProvider';
-import ChannelsProvider from '@components/providers/ChannelsProvider';
 import Layout from '@components/layout';
 import ModalsProvider from '@components/providers/ModalProvider';
 import ShowModals from '@components/Modal/showModals';
@@ -25,6 +21,7 @@ export default function MyApp({ Component, pageProps }: AppProps) {
         defaultOptions: {
           queries: {
             refetchOnWindowFocus: false,
+            staleTime: 0,
           },
         },
       }),
@@ -47,20 +44,12 @@ export default function MyApp({ Component, pageProps }: AppProps) {
           <QueryClientProvider client={queryClient}>
             <HydrationBoundary state={pageProps.dehydratedState}>
               <ReactQueryDevtools initialIsOpen={false} />
-              <ChannelsProvider>
-                <ProfileProvider>
-                  <LastVisitedBoardListsProvider>
-                    <MakeGameProvider>
-                      <ModalsProvider>
-                        <ShowModals />
-                        <Layout>
-                          <Component {...pageProps} />
-                        </Layout>
-                      </ModalsProvider>
-                    </MakeGameProvider>
-                  </LastVisitedBoardListsProvider>
-                </ProfileProvider>
-              </ChannelsProvider>
+              <ModalsProvider>
+                <ShowModals />
+                <Layout>
+                  <Component {...pageProps} />
+                </Layout>
+              </ModalsProvider>
             </HydrationBoundary>
           </QueryClientProvider>
         </MSWComponent>
@@ -73,20 +62,12 @@ export default function MyApp({ Component, pageProps }: AppProps) {
       <QueryClientProvider client={queryClient}>
         <HydrationBoundary state={pageProps.dehydratedState}>
           <ReactQueryDevtools initialIsOpen={false} />
-          <ChannelsProvider>
-            <ProfileProvider>
-              <LastVisitedBoardListsProvider>
-                <MakeGameProvider>
-                  <ModalsProvider>
-                    <ShowModals />
-                    <Layout>
-                      <Component {...pageProps} />
-                    </Layout>
-                  </ModalsProvider>
-                </MakeGameProvider>
-              </LastVisitedBoardListsProvider>
-            </ProfileProvider>
-          </ChannelsProvider>
+          <ModalsProvider>
+            <ShowModals />
+            <Layout>
+              <Component {...pageProps} />
+            </Layout>
+          </ModalsProvider>
         </HydrationBoundary>
       </QueryClientProvider>
     </ThemeProvider>

--- a/src/pages/auth.tsx
+++ b/src/pages/auth.tsx
@@ -1,10 +1,9 @@
 import axios from 'axios';
+import { serialize } from 'cookie';
 import { GetServerSideProps } from 'next';
 
-import { Login } from '@type/login';
 import { SERVER_URL } from '@config/index';
-
-import { serialize } from 'cookie';
+import { Login } from '@type/login';
 
 const Auth = () => {
   return <div></div>;
@@ -24,14 +23,14 @@ export const getServerSideProps: GetServerSideProps<{ data: Login }> = async (co
 
     const { accessToken, refreshToken } = res.data;
 
-    const cookie1 = serialize('accessToken', accessToken, {
+    const accessTokens = serialize('accessToken', accessToken, {
       maxAge: 60 * 60 * 24 * 7,
     });
-    const cookie2 = serialize('refreshToken', refreshToken, {
+    const refreshTokens = serialize('refreshToken', refreshToken, {
       maxAge: 60 * 60 * 24 * 7,
     });
 
-    context.res.setHeader('set-Cookie', [cookie1, cookie2]);
+    context.res.setHeader('set-Cookie', [accessTokens, refreshTokens]);
 
     return {
       redirect: {
@@ -40,11 +39,10 @@ export const getServerSideProps: GetServerSideProps<{ data: Login }> = async (co
       },
     };
   } catch (error) {
-    // 실패 시 login 페이지로 redirect
     return {
       redirect: {
         permanent: false,
-        destination: '/',
+        destination: '/login',
       },
     };
   }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -22,8 +22,8 @@ export default function Home() {
       <List>
         {data?.map((notice, index) => {
           return (
-            <Item>
-              <ItemHeader key={index}>
+            <Item key={index}>
+              <ItemHeader>
                 <ItemIndex>{index + 1}.</ItemIndex>
                 <ItemLink href={notice.noticeLink} target='_blank'>
                   {notice.noticeTitle}

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,53 +1,92 @@
 import styled from '@emotion/styled';
 import Image from 'next/image';
-import { useRouter } from 'next/router';
-import { useEffect } from 'react';
 
 const Login = () => {
-  const router = useRouter();
-
-  useEffect(() => {
-    // 최근 방문한 path 저장
-    if (router.query.callback) {
-      localStorage.setItem('latestVisit', router.query.callback as string);
-    } else {
-      localStorage.setItem('latestVisit', '/');
-    }
-  }, []);
-
   return (
-    <Container>
-      <Wrapper>
-        <Title>League Hub</Title>
-        <KakaoLogin
-          href={`https://kauth.kakao.com/oauth/authorize?client_id=${process.env.NEXT_PUBLIC_CLIENT_ID}&redirect_uri=${process.env.NEXT_PUBLIC_REDIRECT_URI}&response_type=code`}
-        >
-          <Image src='/img/auth/kakao_login.png' alt='kakao_login' width={300} height={55} />
-        </KakaoLogin>
-      </Wrapper>
-    </Container>
+    <Main>
+      <BgMain />
+      <Container>
+        <LogoContainer>
+          <LogoImage src='/img/logo/logo-l.png' width='584' height='101' alt='logo' />
+        </LogoContainer>
+        <Title>당신의 실력을 증명해보세요.</Title>
+        <ContentText>대회 개최부터 운영, 관전까지</ContentText>
+        <ContentText>리그허브에서 한번에..</ContentText>
+
+        <Footer>
+          <FooterText>지금 리그에 참여하세요.</FooterText>
+          <KakaoLogin
+            href={`https://kauth.kakao.com/oauth/authorize?client_id=${process.env.NEXT_PUBLIC_CLIENT_ID}&redirect_uri=${process.env.NEXT_PUBLIC_REDIRECT_URI}&response_type=code`}
+          >
+            <Image src='/img/auth/kakao_login.png' alt='kakao_login' width={300} height={55} />
+          </KakaoLogin>
+        </Footer>
+      </Container>
+    </Main>
   );
 };
 
-export default Login;
+const Main = styled.div`
+  width: 100%;
+  height: 100vh;
 
-const Container = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 100%;
-  height: calc(100vh - 4.5rem);
-`;
-
-const Wrapper = styled.div`
-  display: flex;
   flex-direction: column;
-  row-gap: 10rem;
+
+  color: black;
 `;
 
-const Title = styled.h1`
+const BgMain = styled.div`
+  width: 100%;
+  height: 100vh;
+
+  position: absolute;
+
+  background: url('/img/main/main.png');
+  background-size: 100% 100vh;
+  background-repeat: no-repeat;
+  opacity: 0.6;
+  z-index: -5;
+`;
+
+const Container = styled.div`
+  height: 50rem;
+  width: 60rem;
+
+  margin: 0 auto;
+`;
+
+const LogoContainer = styled.div``;
+
+const LogoImage = styled(Image)`
+  margin: 0 auto;
+`;
+
+const Title = styled.h2`
+  margin: 2rem 0;
+
   text-align: center;
-  font-size: 3rem;
+  font-size: 3.2rem;
 `;
 
+const ContentText = styled.div`
+  text-align: center;
+  font-size: 2.2rem;
+  font-weight: 700;
+`;
 const KakaoLogin = styled.a``;
+
+const FooterText = styled.div`
+  margin: 4rem 0;
+`;
+const Footer = styled.div`
+  margin: 10rem auto 0 auto;
+
+  font-size: 2rem;
+  text-align: center;
+  font-weight: 700;
+`;
+
+export default Login;

--- a/src/pages/mypage.tsx
+++ b/src/pages/mypage.tsx
@@ -155,7 +155,8 @@ const fetchMyPage = async () => {
   } catch (error) {
     return {
       redirect: {
-        destination: '/',
+        destination: '/login',
+        permanent: false,
       },
     };
   }

--- a/src/utils/withAuthentication.tsx
+++ b/src/utils/withAuthentication.tsx
@@ -9,7 +9,12 @@ const withAuthServerSideProps = (getServerSidePropsFunction: () => Promise<any>)
     const accessToken = parse(cookies).accessToken;
 
     if (!accessToken) {
-      throw new Error('401 Unauthorized');
+      return {
+        redirect: {
+          destination: '/',
+          permanent: false,
+        },
+      };
     }
 
     authAPI.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;


### PR DESCRIPTION
## 🤠 개요
미들 웨어를 만들고 Provider 위치를 옮기고 로그인 페이지를 변경했어요.
- closes: #285
<!--
- 이슈번호
- 한줄 설명
- closes: #(이슈번호 입력해주세요)
  -->

## 💫 설명
기존에는 프로필을 api를 요청하고 api 성공 여부에 따라 로그인여부를 판별했는데 토큰이 없으면 반드시 실패하는 불필요한 api 요청이라고 생각해 미들웨어에서 액세스토큰 여부에따라 로그인 여부를 판별했어요. 그리고 인해 로그인했을 때만 channel을 불러와 기존에 _app에서 채널, 프로필 Provider를 layout 내부로 옮겼어요.

[관련 정리 바로가기](https://hyeonjun0530.notion.site/d3eca7b8dc2c4c7cb013eb247cd7af51?pvs=4)


그로인해 로그인을 하지 않으면 기존에 /에서 로그인 컴포넌트를 보여줬는데 /login으로 이동해 로그인 페이지를 보여주도록 변경했어요!

## 📷 스크린샷 (Optional)
<img width="274" alt="12333" src="https://github.com/TheUpperPart/leaguehub-frontend/assets/100738049/908bfe32-622f-4448-abed-7a0f02ed2f72">
